### PR TITLE
DAT completeness check, Electron auto-update & first-run language picker (v0.10.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ node_modules/
 web/dist/
 *.tsbuildinfo
 
-# Runtime data (DB, cached images, temp extraction) — never commit
-data/
-!data/.gitkeep
+# Runtime data (DB, cached images, temp extraction) — never commit.
+# Root-anchored so it does NOT also swallow server/src/data/ (bundled source
+# tables: free-games, cores, frontends).
+/data/
+!/data/.gitkeep
 
 # Local config with secrets
 server/config.local.json

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,13 @@ directories:
   output: release
   buildResources: build
 
+# Update feed for electron-updater. Generates latest.yml alongside the exe; the
+# app checks this repo's GitHub releases and auto-downloads newer versions.
+publish:
+  provider: github
+  owner: x3kim
+  repo: RAChecker
+
 files:
   - electron/**/*
   - server/src/**/*
@@ -34,6 +41,9 @@ nsis:
   allowToChangeInstallationDirectory: true
   deleteAppDataOnUninstall: false
   license: LICENSE
+  # Space-free name so the on-disk file, latest.yml url and the uploaded GitHub
+  # asset all match — otherwise electron-updater 404s on the download.
+  artifactName: "RAChecker-Setup-${version}.exe"
 
 portable:
   artifactName: "RAChecker-${version}-portable.exe"

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,9 +1,12 @@
 // RAChecker desktop shell. Boots the Fastify server in-process (Electron's
 // Node has node:sqlite since v35) and opens the UI in a BrowserWindow.
-import { app, BrowserWindow, dialog, shell } from 'electron';
+import { app, BrowserWindow, dialog, shell, ipcMain } from 'electron';
+import electronUpdater from 'electron-updater';
 import { createServer } from 'node:net';
 import { join, dirname } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
+
+const { autoUpdater } = electronUpdater;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -85,7 +88,7 @@ async function boot() {
       autoHideMenuBar: true,
       title: 'RAChecker',
       icon: join(ROOT, 'build', 'icon.ico'),
-      webPreferences: { contextIsolation: true, nodeIntegration: false, sandbox: true },
+      webPreferences: { contextIsolation: true, nodeIntegration: false, sandbox: true, preload: join(__dirname, 'preload.cjs') },
     });
     // External links (RetroAchievements, GitHub …) open in the real browser.
     win.webContents.setWindowOpenHandler(({ url: target }) => {
@@ -94,8 +97,38 @@ async function boot() {
     });
     win.on('closed', () => { win = null; });
     await win.loadURL(url);
+    if (app.isPackaged) setupAutoUpdate();
   } catch (err) {
     dialog.showErrorBox('RAChecker konnte nicht starten', String(err?.stack || err));
     app.quit();
   }
 }
+
+// ---- auto-update (electron-updater, GitHub releases feed) -----------------
+// Full-auto flow: on launch we check GitHub; if a newer release exists it is
+// downloaded in the background, then the UI offers a one-click "restart &
+// install". The publish feed + latest.yml come from electron-builder.yml.
+function pushStatus(data) { try { win?.webContents.send('update:status', data); } catch { /* window gone */ } }
+
+function setupAutoUpdate() {
+  autoUpdater.autoDownload = true;             // download as soon as an update is found
+  autoUpdater.autoInstallOnAppQuit = true;     // also install silently on a normal quit
+  autoUpdater.on('checking-for-update', () => pushStatus({ state: 'checking' }));
+  autoUpdater.on('update-available', (info) => pushStatus({ state: 'available', version: info?.version }));
+  autoUpdater.on('update-not-available', (info) => pushStatus({ state: 'none', version: info?.version }));
+  autoUpdater.on('error', (err) => pushStatus({ state: 'error', error: String(err?.message || err) }));
+  autoUpdater.on('download-progress', (p) => pushStatus({ state: 'downloading', percent: Math.round(p?.percent || 0) }));
+  autoUpdater.on('update-downloaded', (info) => pushStatus({ state: 'downloaded', version: info?.version }));
+  autoUpdater.checkForUpdates().catch((e) => pushStatus({ state: 'error', error: String(e?.message || e) }));
+}
+
+// The renderer (via preload) can trigger a manual check and the install/restart.
+ipcMain.handle('update:check', async () => {
+  try { await autoUpdater.checkForUpdates(); return { ok: true }; }
+  catch (e) { return { ok: false, error: String(e?.message || e) }; }
+});
+ipcMain.handle('update:install', () => {
+  // Defer so the IPC reply is sent before the app tears down to install.
+  setImmediate(() => { try { autoUpdater.quitAndInstall(); } catch { /* ignore */ } });
+  return { ok: true };
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,16 @@
+// Sandboxed preload. Bridges the auto-updater status/commands from the main
+// process to the web UI (which is served over http://127.0.0.1). Only a tiny,
+// explicit surface is exposed — no Node access leaks to the page.
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('raUpdate', {
+  isElectron: true,
+  // Subscribe to update status pushes. Returns an unsubscribe function.
+  onStatus: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on('update:status', handler);
+    return () => ipcRenderer.removeListener('update:status', handler);
+  },
+  check: () => ipcRenderer.invoke('update:check'),
+  install: () => ipcRenderer.invoke('update:install'),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,28 @@
 {
   "name": "ra-checker",
-  "version": "0.6.0",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ra-checker",
-      "version": "0.6.0",
+      "version": "0.9.5",
       "hasInstallScript": true,
+      "license": "MIT",
       "workspaces": [
         "server",
         "web"
       ],
+      "dependencies": {
+        "@fastify/cors": "^10.0.1",
+        "@fastify/multipart": "^10.0.0",
+        "@fastify/static": "^8.0.3",
+        "7zip-min": "^2.1.0",
+        "electron-updater": "^6.8.9",
+        "fastify": "^5.2.1",
+        "node-stream-zip": "^1.15.0",
+        "node-unrar-js": "^2.0.2"
+      },
       "devDependencies": {
         "concurrently": "^9.1.2",
         "electron": "^43.1.0",
@@ -2709,7 +2720,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -2939,7 +2949,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -3272,7 +3281,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3629,6 +3637,34 @@
       "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -4144,7 +4180,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4380,7 +4415,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4668,7 +4702,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4757,7 +4790,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4780,7 +4812,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/light-my-request": {
@@ -5100,6 +5131,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -5323,7 +5367,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6348,7 +6391,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6757,6 +6799,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6888,7 +6936,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -7168,7 +7215,7 @@
     },
     "server": {
       "name": "ra-checker-server",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",
         "@fastify/multipart": "^10.0.0",
@@ -7181,7 +7228,7 @@
     },
     "web": {
       "name": "ra-checker-web",
-      "version": "0.1.0",
+      "version": "0.9.5",
       "dependencies": {
         "lucide-react": "^0.460.0",
         "motion": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "RetroAchievements ROM Compatibility Checker — scan your ROM library and find which games can earn achievements.",
@@ -32,6 +32,7 @@
     "@fastify/multipart": "^10.0.0",
     "@fastify/static": "^8.0.3",
     "7zip-min": "^2.1.0",
+    "electron-updater": "^6.8.9",
     "fastify": "^5.2.1",
     "node-stream-zip": "^1.15.0",
     "node-unrar-js": "^2.0.2"

--- a/server/src/dat.js
+++ b/server/src/dat.js
@@ -1,0 +1,166 @@
+// DAT completeness. Parses No-Intro/Redump/logiqx (XML) and ClrMamePro (text)
+// DAT catalogs and computes raw-file CRC32 for matching against the collection.
+// This is a SEPARATE dimension from the RetroAchievements hash (which strips
+// iNES headers, byte-swaps N64, hashes arcade filenames, …): DATs universally
+// carry the CRC32 of the untouched file, so completeness is matched on that.
+import { createReadStream } from 'node:fs';
+import { getConsoles } from './db.js';
+
+// ---- CRC32 (streaming, table-based; independent of zlib.crc32 availability) --
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function toHex(crc) { return (crc >>> 0).toString(16).padStart(8, '0'); }
+
+// Stream a loose file and return its CRC32 as lowercase 8-char hex.
+export function crc32File(filePath, { signal } = {}) {
+  return new Promise((resolve, reject) => {
+    let crc = 0xFFFFFFFF;
+    const rs = createReadStream(filePath);
+    const onAbort = () => rs.destroy(new Error('aborted'));
+    if (signal) {
+      if (signal.aborted) { rs.destroy(); return reject(new Error('aborted')); }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+    rs.on('data', (chunk) => {
+      for (let i = 0; i < chunk.length; i++) crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ chunk[i]) & 0xFF];
+    });
+    rs.on('error', (e) => { if (signal) signal.removeEventListener('abort', onAbort); reject(e); });
+    rs.on('end', () => { if (signal) signal.removeEventListener('abort', onAbort); resolve(toHex(crc ^ 0xFFFFFFFF)); });
+  });
+}
+
+// CRC32 of a member inside a .zip — read straight from the central directory,
+// no decompression needed (this is what makes matching zip collections cheap).
+export async function crc32ZipEntry(filePath, innerName) {
+  const { default: StreamZip } = await import('node-stream-zip');
+  const zip = new StreamZip.async({ file: filePath });
+  try {
+    const entries = await zip.entries();
+    const entry = entries[innerName] || Object.values(entries).find((e) => e.name === innerName);
+    if (!entry || entry.crc == null) return null;
+    return toHex(entry.crc);
+  } finally {
+    await zip.close().catch(() => {});
+  }
+}
+
+// ---- DAT parsing -----------------------------------------------------------
+function decodeXml(s) {
+  return String(s)
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&amp;/g, '&');
+}
+function xmlAttr(tag, name) {
+  const m = tag.match(new RegExp(name + '\\s*=\\s*"([^"]*)"', 'i')) || tag.match(new RegExp(name + "\\s*=\\s*'([^']*)'", 'i'));
+  return m ? decodeXml(m[1]) : null;
+}
+
+function parseXmlDat(text) {
+  const header = {};
+  const hm = text.match(/<header\b[^>]*>([\s\S]*?)<\/header>/i);
+  if (hm) {
+    const inner = hm[1];
+    const pick = (k) => { const m = inner.match(new RegExp('<' + k + '\\b[^>]*>([\\s\\S]*?)</' + k + '>', 'i')); return m ? decodeXml(m[1]).trim() : null; };
+    header.name = pick('name');
+    header.description = pick('description');
+    header.version = pick('version');
+  }
+  const entries = [];
+  const gameRe = /<(?:game|machine)\b([^>]*)>([\s\S]*?)<\/(?:game|machine)>/gi;
+  let g;
+  while ((g = gameRe.exec(text))) {
+    const gameName = xmlAttr(g[1], 'name');
+    const body = g[2];
+    const romRe = /<rom\b([^>]*?)\/?>/gi;
+    let r;
+    while ((r = romRe.exec(body))) {
+      const a = r[1];
+      const crc = xmlAttr(a, 'crc');
+      const md5 = xmlAttr(a, 'md5');
+      const sha1 = xmlAttr(a, 'sha1');
+      if (!crc && !md5 && !sha1) continue; // e.g. <rom status="nodump"/>
+      entries.push({
+        game_name: gameName,
+        rom_name: xmlAttr(a, 'name'),
+        size: Number(xmlAttr(a, 'size')) || null,
+        crc, md5, sha1,
+      });
+    }
+  }
+  return { header, entries };
+}
+
+// Iterate balanced `game (...)` / `machine (...)` blocks in a ClrMamePro DAT.
+function* cmProBlocks(text) {
+  const re = /\b(?:game|machine|set)\s*\(/g;
+  let m;
+  while ((m = re.exec(text))) {
+    let i = m.index + m[0].length; let depth = 1;
+    const start = i;
+    while (i < text.length && depth > 0) { const ch = text[i]; if (ch === '(') depth++; else if (ch === ')') depth--; i++; }
+    yield text.slice(start, i - 1);
+    re.lastIndex = i;
+  }
+}
+function cmVal(block, key) {
+  const m = block.match(new RegExp('\\b' + key + '\\s+"([^"]*)"')) || block.match(new RegExp('\\b' + key + '\\s+([^\\s)]+)'));
+  return m ? m[1] : null;
+}
+function parseClrMameDat(text) {
+  const header = {};
+  const hm = text.match(/clrmamepro\s*\(([\s\S]*?)\)/i);
+  if (hm) {
+    header.name = cmVal(hm[1], 'name');
+    header.description = cmVal(hm[1], 'description');
+    header.version = cmVal(hm[1], 'version');
+  }
+  const entries = [];
+  for (const block of cmProBlocks(text)) {
+    const firstRom = block.search(/\brom\s*\(/);
+    const gameHead = firstRom >= 0 ? block.slice(0, firstRom) : block;
+    const gameName = cmVal(gameHead, 'name');
+    const romRe = /\brom\s*\(([^)]*)\)/g;
+    let r;
+    while ((r = romRe.exec(block))) {
+      const rb = r[1];
+      const crc = cmVal(rb, 'crc');
+      const md5 = cmVal(rb, 'md5');
+      const sha1 = cmVal(rb, 'sha1');
+      if (!crc && !md5 && !sha1) continue;
+      entries.push({
+        game_name: gameName,
+        rom_name: cmVal(rb, 'name'),
+        size: Number(cmVal(rb, 'size')) || null,
+        crc, md5, sha1,
+      });
+    }
+  }
+  return { header, entries };
+}
+
+export function parseDat(text) {
+  const head = text.slice(0, 4000).trimStart();
+  const isXml = head.startsWith('<?xml') || head.startsWith('<!DOCTYPE') || /<datafile[\s>]/i.test(head) || /<mame[\s>]/i.test(head);
+  return isXml ? parseXmlDat(text) : parseClrMameDat(text);
+}
+
+// Best-effort RA console guess from the DAT header name (informational only —
+// matching is by CRC and does not depend on this).
+export function guessConsole(headerName) {
+  const h = (headerName || '').toLowerCase();
+  if (!h) return null;
+  let best = null;
+  for (const c of getConsoles()) {
+    const nm = (c.name || '').toLowerCase();
+    if (nm.length >= 3 && h.includes(nm) && (!best || nm.length > best.len)) best = { id: c.id, len: nm.length };
+  }
+  return best ? best.id : null;
+}

--- a/server/src/data/cores.js
+++ b/server/src/data/cores.js
@@ -1,0 +1,409 @@
+// RetroArch core recommendations per RetroAchievements system id.
+// Sourced from RA's emulator-support docs; data only, no runtime network.
+//
+// Core ids were cross-checked against the authoritative libretro core-info
+// listing (github.com/libretro/libretro-core-info) so the filenames below
+// are real, current libretro core identifiers.
+
+export const CORES_SOURCE = 'https://docs.retroachievements.org/general/emulator-support-and-issues.html';
+
+// RA-compatible frontends that can run libretro cores with achievement / hardcore support.
+export const RA_FRONTENDS = [
+  {
+    name: 'RetroArch',
+    url: 'https://www.retroarch.com/index.php?page=platforms',
+    note: 'Reference libretro frontend; supports 40+ systems.'
+  },
+  {
+    name: 'RALibRetro',
+    url: 'https://retroachievements.org/downloads',
+    note: 'Lightweight libretro frontend maintained by RetroAchievements; supports 40+ systems.'
+  },
+  {
+    name: 'Firelight',
+    url: 'https://biscuitcakes.itch.io/firelight',
+    note: 'Third-party libretro frontend; supports 10+ systems.'
+  },
+  {
+    name: 'Manic EMU',
+    url: 'https://github.com/Manic-EMU/ManicEMU',
+    note: 'iOS libretro frontend; supports 10+ systems.'
+  },
+  {
+    name: 'Delta',
+    url: 'https://apps.apple.com/us/app/delta-game-emulator/id1048524688',
+    note: 'iOS libretro frontend; supports 5+ systems.'
+  }
+];
+
+// consoleId -> { cores: [{ id, name, achievements, hardcore, note }], standalone: [string] }
+//   id           libretro core identifier WITHOUT the .dll/.so suffix, e.g. 'snes9x_libretro'
+//   name         human-readable core name, e.g. 'Snes9x'
+//   achievements true when the core supports RA achievements
+//   hardcore     true when RA hardcore mode is supported by that core
+//   note         short English note or null
+// The FIRST core in `cores` is the recommended default.
+export const CORES_BY_CONSOLE = {
+  1: { // Genesis/Mega Drive
+    cores: [
+      { id: 'genesis_plus_gx_libretro', name: 'Genesis Plus GX', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'picodrive_libretro', name: 'PicoDrive', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  2: { // Nintendo 64
+    cores: [
+      { id: 'mupen64plus_next_libretro', name: 'Mupen64Plus-Next', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'parallel_n64_libretro', name: 'ParaLLEl N64', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  3: { // SNES
+    cores: [
+      { id: 'snes9x_libretro', name: 'Snes9x', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'mesen-s_libretro', name: 'Mesen-S', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  4: { // Game Boy
+    cores: [
+      { id: 'gambatte_libretro', name: 'Gambatte', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'gearboy_libretro', name: 'Gearboy', achievements: true, hardcore: true, note: null },
+      { id: 'mgba_libretro', name: 'mGBA', achievements: true, hardcore: true, note: null },
+      { id: 'vbam_libretro', name: 'VBA-M', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  5: { // Game Boy Advance
+    cores: [
+      { id: 'mgba_libretro', name: 'mGBA', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'vbam_libretro', name: 'VBA-M', achievements: true, hardcore: true, note: null },
+      { id: 'mednafen_gba_libretro', name: 'Beetle GBA', achievements: true, hardcore: true, note: null },
+      { id: 'vba_next_libretro', name: 'VBA Next', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  6: { // Game Boy Color
+    cores: [
+      { id: 'gambatte_libretro', name: 'Gambatte', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'gearboy_libretro', name: 'Gearboy', achievements: true, hardcore: true, note: null },
+      { id: 'mgba_libretro', name: 'mGBA', achievements: true, hardcore: true, note: null },
+      { id: 'vbam_libretro', name: 'VBA-M', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  7: { // NES/Famicom
+    cores: [
+      { id: 'fceumm_libretro', name: 'FCEUmm', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'mesen_libretro', name: 'Mesen', achievements: true, hardcore: true, note: null },
+      { id: 'quicknes_libretro', name: 'QuickNES', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  8: { // PC Engine/TurboGrafx-16/SuperGrafx
+    cores: [
+      { id: 'mednafen_supergrafx_libretro', name: 'Beetle SuperGrafx', achievements: true, hardcore: true, note: 'Most recommended core; also covers PC Engine and PC Engine CD.' },
+      { id: 'mednafen_pce_fast_libretro', name: 'Beetle PCE Fast', achievements: true, hardcore: true, note: 'Faster but not SuperGrafx compatible.' }
+    ],
+    standalone: []
+  },
+  9: { // Sega CD
+    cores: [
+      { id: 'genesis_plus_gx_libretro', name: 'Genesis Plus GX', achievements: true, hardcore: true, note: 'Unmapped RAM issues on some games.' },
+      { id: 'picodrive_libretro', name: 'PicoDrive', achievements: true, hardcore: true, note: 'Unmapped RAM issues on some games.' }
+    ],
+    standalone: []
+  },
+  10: { // 32X
+    cores: [
+      { id: 'picodrive_libretro', name: 'PicoDrive', achievements: true, hardcore: true, note: 'Issues with some games; the BizHawk build is recommended for problem titles.' }
+    ],
+    standalone: []
+  },
+  11: { // Master System/Mark III
+    cores: [
+      { id: 'genesis_plus_gx_libretro', name: 'Genesis Plus GX', achievements: true, hardcore: true, note: null },
+      { id: 'gearsystem_libretro', name: 'Gearsystem', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  12: { // PlayStation
+    cores: [
+      { id: 'mednafen_psx_hw_libretro', name: 'Beetle PSX HW', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'mednafen_psx_libretro', name: 'Beetle PSX', achievements: true, hardcore: true, note: null },
+      { id: 'swanstation_libretro', name: 'SwanStation', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['DuckStation']
+  },
+  13: { // Atari Lynx
+    cores: [
+      { id: 'handy_libretro', name: 'Handy', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'mednafen_lynx_libretro', name: 'Beetle Lynx', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  14: { // Neo Geo Pocket (Color)
+    cores: [
+      { id: 'mednafen_ngp_libretro', name: 'Beetle NeoPop', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  15: { // Game Gear
+    cores: [
+      { id: 'genesis_plus_gx_libretro', name: 'Genesis Plus GX', achievements: true, hardcore: true, note: null },
+      { id: 'gearsystem_libretro', name: 'Gearsystem', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  16: { // GameCube
+    cores: [],
+    standalone: ['Dolphin', 'DolphinUWP']
+  },
+  17: { // Atari Jaguar
+    cores: [
+      { id: 'virtualjaguar_libretro', name: 'Virtual Jaguar', achievements: true, hardcore: true, note: 'No save states, no CD emulation; numerous issues per RA docs.' }
+    ],
+    standalone: []
+  },
+  18: { // Nintendo DS
+    cores: [
+      { id: 'desmume_libretro', name: 'DeSmuME', achievements: true, hardcore: true, note: 'No DSi emulation.' },
+      { id: 'melonds_libretro', name: 'melonDS', achievements: true, hardcore: true, note: null },
+      { id: 'melondsds_libretro', name: 'melonDS DS', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  19: { // Wii
+    cores: [],
+    standalone: ['Dolphin', 'DolphinUWP']
+  },
+  21: { // PlayStation 2
+    cores: [],
+    standalone: ['PCSX2', 'XBSX2', 'ARMSX2']
+  },
+  23: { // Magnavox Odyssey 2 / Philips Videopac+
+    cores: [
+      { id: 'o2em_libretro', name: 'O2EM', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  24: { // Pokemon Mini
+    cores: [
+      { id: 'pokemini_libretro', name: 'PokeMini', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  25: { // Atari 2600
+    cores: [
+      { id: 'stella_libretro', name: 'Stella', achievements: true, hardcore: true, note: null },
+      { id: 'stella2014_libretro', name: 'Stella 2014', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  27: { // Arcade
+    cores: [
+      { id: 'fbneo_libretro', name: 'FinalBurn Neo', achievements: true, hardcore: true, note: 'Some arcade boards may not be fully exposed.' },
+      { id: 'flycast_libretro', name: 'Flycast', achievements: true, hardcore: true, note: 'For Atomiswave and NAOMI 1/2 boards.' }
+    ],
+    standalone: []
+  },
+  28: { // Virtual Boy
+    cores: [
+      { id: 'mednafen_vb_libretro', name: 'Beetle VB', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  29: { // MSX
+    cores: [
+      { id: 'bluemsx_libretro', name: 'blueMSX', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  33: { // SG-1000
+    cores: [
+      { id: 'genesis_plus_gx_libretro', name: 'Genesis Plus GX', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'bluemsx_libretro', name: 'blueMSX', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  37: { // Amstrad CPC
+    cores: [
+      { id: 'cap32_libretro', name: 'Caprice32', achievements: true, hardcore: true, note: 'Lacks disk writing support.' }
+    ],
+    standalone: []
+  },
+  38: { // Apple II
+    cores: [],
+    standalone: ['RAppleWin']
+  },
+  39: { // Saturn
+    cores: [
+      { id: 'mednafen_saturn_libretro', name: 'Beetle Saturn', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['Yaba Sanshiro']
+  },
+  40: { // Dreamcast
+    cores: [
+      { id: 'flycast_libretro', name: 'Flycast', achievements: true, hardcore: true, note: 'Disable threaded rendering for proper save states.' }
+    ],
+    standalone: ['Flycast']
+  },
+  41: { // PSP
+    cores: [
+      { id: 'ppsspp_libretro', name: 'PPSSPP', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['PPSSPP']
+  },
+  43: { // 3DO
+    cores: [
+      { id: 'opera_libretro', name: 'Opera', achievements: true, hardcore: true, note: 'May have BIOS-dependent issues.' }
+    ],
+    standalone: []
+  },
+  44: { // ColecoVision
+    cores: [
+      { id: 'bluemsx_libretro', name: 'blueMSX', achievements: true, hardcore: true, note: null },
+      { id: 'gearcoleco_libretro', name: 'Gearcoleco', achievements: true, hardcore: true, note: 'Purpose-built ColecoVision core; standard libretro core, not explicitly named on the fetched RA docs snapshot.' }
+    ],
+    standalone: ['RAMeka']
+  },
+  45: { // Intellivision
+    cores: [
+      { id: 'freeintv_libretro', name: 'FreeIntv', achievements: true, hardcore: true, note: 'Crashes on reset; Intellivoice not emulated.' }
+    ],
+    standalone: []
+  },
+  46: { // Vectrex
+    cores: [
+      { id: 'vecx_libretro', name: 'vecx', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  47: { // PC-8000/8800
+    cores: [
+      { id: 'quasi88_libretro', name: 'QUASI88', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['RAQUASI88']
+  },
+  49: { // PC-FX
+    cores: [
+      { id: 'mednafen_pcfx_libretro', name: 'Beetle PC-FX', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  51: { // Atari 7800
+    cores: [
+      { id: 'prosystem_libretro', name: 'ProSystem', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  53: { // WonderSwan (Color)
+    cores: [
+      { id: 'mednafen_wswan_libretro', name: 'Beetle Cygne', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  56: { // Neo Geo CD
+    cores: [
+      { id: 'neocd_libretro', name: 'NeoCD', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  57: { // Fairchild Channel F
+    cores: [
+      { id: 'freechaf_libretro', name: 'FreeChaF', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  63: { // Watara Supervision
+    cores: [
+      { id: 'potator_libretro', name: 'Potator', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  69: { // Mega Duck
+    cores: [
+      { id: 'sameduck_libretro', name: 'SameDuck', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  71: { // Arduboy
+    cores: [
+      { id: 'ardens_libretro', name: 'Ardens', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'arduous_libretro', name: 'Arduous', achievements: true, hardcore: true, note: 'Cannot emulate Arduboy FX.' }
+    ],
+    standalone: []
+  },
+  72: { // WASM-4
+    cores: [
+      { id: 'wasm4_libretro', name: 'WASM-4', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  73: { // Arcadia 2001
+    cores: [
+      { id: 'amiarcadia_libretro', name: 'AmiArcadia', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['WinArcadia', 'DroidArcadia']
+  },
+  74: { // Interton VC 4000
+    cores: [
+      { id: 'amiarcadia_libretro', name: 'AmiArcadia', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['WinArcadia', 'DroidArcadia']
+  },
+  75: { // Elektor TV Games Computer
+    cores: [
+      { id: 'amiarcadia_libretro', name: 'AmiArcadia', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: ['WinArcadia', 'DroidArcadia']
+  },
+  76: { // PC Engine CD/TurboGrafx-CD
+    cores: [
+      { id: 'mednafen_supergrafx_libretro', name: 'Beetle SuperGrafx', achievements: true, hardcore: true, note: 'Most recommended core for this system.' },
+      { id: 'mednafen_pce_fast_libretro', name: 'Beetle PCE Fast', achievements: true, hardcore: true, note: 'Faster but not SuperGrafx compatible.' }
+    ],
+    standalone: []
+  },
+  77: { // Atari Jaguar CD
+    cores: [],
+    standalone: []
+  },
+  78: { // Nintendo DSi
+    cores: [
+      { id: 'melondsds_libretro', name: 'melonDS DS', achievements: true, hardcore: true, note: 'No save state support currently.' }
+    ],
+    standalone: ['melonDS Android']
+  },
+  80: { // Uzebox
+    cores: [
+      { id: 'uzem_libretro', name: 'Uzem', achievements: true, hardcore: true, note: null }
+    ],
+    standalone: []
+  },
+  81: { // Famicom Disk System
+    cores: [
+      { id: 'mesen_libretro', name: 'Mesen', achievements: true, hardcore: true, note: 'Most recommended core for this system.' }
+    ],
+    standalone: ['RANes']
+  }
+};
+
+// Return { cores, standalone } for a RetroAchievements console id, with empty defaults if unknown.
+export function coresFor(consoleId) {
+  const entry = CORES_BY_CONSOLE[consoleId];
+  if (!entry) return { cores: [], standalone: [] };
+  return entry;
+}
+
+// Return the recommended (first) core object for a console id, or null if none.
+export function recommendedCore(consoleId) {
+  const { cores } = coresFor(consoleId);
+  return cores.length > 0 ? cores[0] : null;
+}
+
+// 'snes9x_libretro' -> 'snes9x_libretro.dll' on win32, '.so' elsewhere.
+export function coreFileName(coreId, platform = process.platform) {
+  const ext = platform === 'win32' ? '.dll' : '.so';
+  return `${coreId}${ext}`;
+}

--- a/server/src/data/free-games.js
+++ b/server/src/data/free-games.js
@@ -1,0 +1,162 @@
+// Curated catalog of legally free / homebrew games that have (or may have)
+// RetroAchievements sets. Source: RetroAchievements docs "Free Games" page.
+// Data only — no network access at runtime.
+//
+// Transcribed directly from the page's rendered HTML (not from a markdown
+// summary) to avoid encoding artifacts. A few author fields were lightly
+// cleaned of parenthetical asides that are notes about the game rather than
+// part of the author's name (e.g. NSFW warnings, "no longer available"
+// remarks); nothing was invented. "Bootee" had a broken markdown link left
+// in the source page's author text ("[Mojo Twins](https://www.mojontwins.com/")
+// — cleaned to the intended "Mojo Twins" to match the other Mojo Twins credit
+// on this same page. "Super Boss Gaiden"'s author is transcribed verbatim as
+// "superfamicom.org (??)" — the "(??)" is the page authors' own uncertainty
+// marker, not something we added. Every system section on the source page at
+// fetch time (Atari 2600 through Virtual Boy) was retrieved in full; there
+// were no truncated/missing sections.
+
+export const FREE_GAMES_SOURCE = 'https://docs.retroachievements.org/orphaned/free-games.html';
+export const FREE_GAMES_UPDATED = '2026-07-24';
+
+// Compute a URL's hostname without a leading "www.". Returns null if the URL
+// fails to parse (never guess/hardcode a host).
+function hostOf(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+// Raw entries as transcribed from the source page, grouped by system section
+// in the same order they appear there. `host` is derived below, not typed
+// here, so it can never drift from the actual url.
+const RAW_ENTRIES = [
+  // --- Atari 2600 ---
+  { title: 'Amoeba Jump', author: 'Dionoid', url: 'http://atariage.com/forums/topic/280211-amoeba-jump/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'AVGN K.O. Boxing', author: 'Devin Cook', url: 'https://atariage.com/forums/topic/149089-angry-video-game-nerd-ko-boxing/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Flappy', author: 'Michael Haas', url: 'https://atariage.com/forums/topic/222161-flappy-my-1st-released-game/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Go Fish!', author: 'Bob Montgomery', url: 'https://www.atariage.com/software_page.php?SoftwareLabelID=2721', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Halo 2600', author: 'Ed Fries', url: 'https://atariage.com/forums/topic/166916-halo-for-the-2600-released-at-cge-download-the-game-here/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'INV+', author: 'Erik Mooney, Piero Cavina', url: 'https://atariage.com/software_page.php?SoftwareLabelID=2691', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Oystron', author: 'Piero Cavina', url: 'https://atariage.com/software_page.php?SoftwareLabelID=869', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Pac-Man 4K', author: 'Dennis Debro', url: 'https://atariage.com/forums/topic/277992-pac-man-4k-old-vs-new-clarification-2600/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Princess Rescue', author: 'Chris Spry', url: 'https://atariage.com/forums/topic/215058-princess-rescue-binaries-released/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Sheep It Up!', author: 'Dr. Ludos', url: 'https://drludos.itch.io/sheep-it-up-2600', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Snake-2600', author: 'Wickeycolombus', url: 'https://atariage.com/forums/blogs/entry/7740-snake-2600/', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Tetris26', author: 'Colin Hughes', url: 'https://github.com/udibr/tetris26', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Video Simon', author: 'Mark De Smet', url: 'https://atariage.com/software_page.php?SoftwareLabelID=873', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Wall Jump Ninja', author: 'Walaber', url: 'https://atariage.com/forums/topic/232200-ninja-wall-jump-game-wip/page-6#entry3154689', consoleId: 25, systemLabel: 'Atari 2600' },
+  { title: 'Zippy the Porcupine', author: 'Chris Spry', url: 'https://atariage.com/forums/topic/269247-zippy-the-porcupine-binary-released/', consoleId: 25, systemLabel: 'Atari 2600' },
+
+  // --- Game Boy ---
+  { title: 'Dangan GB', author: 'snorpung', url: 'https://snorpung.itch.io/dangan-gb', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Deadeus', author: '-IZMA-', url: 'https://izma.itch.io/deadeus', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Deep Forest', author: 'Kevin Trepanier', url: 'https://small.itch.io/deep-forest', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: "Dino's Offline Adventure", author: 'gaming monster', url: 'https://gaming-monster.itch.io/dinos-offline-adventure', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'DMG Deals Damage', author: 'Dr. Ludos', url: 'https://drludos.itch.io/dmg-deals-damage', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Flappy Boy', author: 'zurashu', url: 'https://zurashu.itch.io/flappy-boy', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Petite Professional GB', author: 'ocarson', url: 'https://ocarson.itch.io/petite-professional-gb', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: "Pretty Princess' Castle Escape", author: 'sergeeo', url: 'https://sergeeo.itch.io/pretty-princess-castle-escape', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Popcorn Caravan', author: 'cabbage', url: 'https://cabbage.itch.io/gbjam6', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Snake', author: 'Donald Hays', url: 'https://donaldhays.com/projects/snake/', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'The Binding of Isaac: Game Boy Edition', author: 'Joshua Robertson', url: 'https://jrob774.itch.io/the-binding-of-isaac-gbjam8-edition', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Tobu Tobu Girl', author: 'TangramGames', url: 'https://tangramgames.dk/tobutobugirl/', consoleId: 4, systemLabel: 'Game Boy' },
+  { title: 'Waifu Clicker', author: 'Refresh Games', url: 'https://refreshgames.itch.io/waifu-clicker', consoleId: 4, systemLabel: 'Game Boy' },
+
+  // --- Game Boy Color ---
+  { title: 'Hong Kong 2099', author: 'Bl4h8L4hBl4h', url: 'https://bl4h8l4hbl4h.itch.io/hong-kong-2099-for-gameboy', consoleId: 6, systemLabel: 'Game Boy Color' },
+  { title: 'Tobu Tobu Girl Deluxe', author: 'TangramGames', url: 'https://tangramgames.dk/tobutobugirldx/', consoleId: 6, systemLabel: 'Game Boy Color' },
+  { title: 'Warp Coin Catastrophe', author: 'Proximity Sound', url: 'http://game.warp.world/', consoleId: 6, systemLabel: 'Game Boy Color' },
+
+  // --- Game Boy Advance ---
+  { title: 'Celeste Classic', author: 'Maddy Thorson and Noel Berry', url: 'https://github.com/JeffRuLz/Celeste-Classic-GBA/releases/tag/v1.0', consoleId: 5, systemLabel: 'Game Boy Advance' },
+  { title: 'Pocket Meat', author: 'BomberDev', url: 'https://bomberdev.itch.io/pocket-meat', consoleId: 5, systemLabel: 'Game Boy Advance' },
+  { title: 'Snakes', author: 'BadMrFrostyXXX', url: 'http://puu.sh/g3QGQ/dd42da818e.zip', consoleId: 5, systemLabel: 'Game Boy Advance' },
+
+  // --- Nintendo DS ---
+  { title: 'Anguna DS', author: 'Nathan Tolbert', url: 'https://gamebrew.org/wiki/Anguna', consoleId: 18, systemLabel: 'Nintendo DS' },
+  { title: 'Bubble Wrap DS', author: 'Prodigy Games', url: 'https://www.gamebrew.org/wiki/Bubble_Wrap_DS', consoleId: 18, systemLabel: 'Nintendo DS' },
+  { title: 'Crocodingus in Cube Island', author: 'PXLteam', url: 'https://gamebrew.org/wiki/Crocodingus_in_Cube_Island', consoleId: 18, systemLabel: 'Nintendo DS' },
+  { title: 'EunHye DS', author: 'beadeulpiri', url: 'https://gamebrew.org/wiki/EunHye_DS', consoleId: 18, systemLabel: 'Nintendo DS' },
+  { title: 'Slide Puzzles', author: 'Neumann(Puzzle), roronoa(Migraine), Dustin(15-16)', url: 'https://retroachievements.org/viewtopic.php?t=10222', consoleId: 18, systemLabel: 'Nintendo DS' },
+  { title: 'Ultimate Sliding Puzzle', author: 'Kukulcan, LOBO', url: 'https://retroachievements.org/viewtopic.php?t=10793', consoleId: 18, systemLabel: 'Nintendo DS' },
+
+  // --- Mega Drive/Genesis ---
+  { title: "30 Years of Nintendon't", author: 'Dr. Ludos', url: 'https://drludos.itch.io/30-years-of-nintendont', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: 'Cave Story MD', author: 'andwn', url: 'https://github.com/andwn/cave-story-md/releases', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: 'Double Cooked', author: 'Zhamul, mipelius, Miranda', url: 'https://zhamul.itch.io/double-cooked', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: "L'ABBAYE DES MORTS", author: 'Locomalito', url: 'https://playonretro.itch.io/labbaye-des-morts-megadrivegenesis-por-002', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: 'Mega Flappy Sis', author: 'Lennart', url: 'https://harlequin.itch.io/mega-flappy-sys', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: 'Pringles Game', author: 'MtChocolate', url: 'http://68000.web.fc2.com/pringles.html', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: 'Uwol - Quest For Money', author: 'Shiru', url: 'https://shiru.untergrund.net/files/smd/uwol_quest_for_money.zip', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+  { title: 'ZOOMING SECRETARY: GOING PANIC', author: 'Playonretro', url: 'https://playonretro.itch.io/zooming-secretary-going-panic-megadrivegenesis-por-006', consoleId: 1, systemLabel: 'Genesis/Mega Drive' },
+
+  // --- NES ---
+  { title: '2048', author: 'tsone', url: 'https://www.romhacking.net/homebrew/65/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Alter Ego', author: 'Shiru', url: 'https://shiru.untergrund.net/files/nes/alter_ego.zip', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Blade Buster', author: 'High Level Challenge', url: 'http://hlc6502.web.fc2.com/BB_20120301.zip', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Böbl', author: 'Morphcat Games', url: 'https://neshomebrew.ca/contest19/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Bootee', author: 'Mojo Twins', url: 'https://www.mojontwins.com/juegos_mojonos/bootee-nes/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Cookie Clicker', author: 'Damian Yerrick', url: 'http://pineight.com/cookieclicker/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'D-Pad Hero', author: 'Kent Hansen, Andreas Pedersen', url: 'https://dpadhero.com/Download.html', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'D-Pad Hero 2', author: 'Kent Hansen, Andreas Pedersen', url: 'https://dpadhero.com/Download.html', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Filthy Kitchen', author: 'dustmop', url: 'https://dustmop.itch.io/filthy-kitchen', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Function', author: null, url: 'http://nesdevcompo.nintendoage.com/contest14/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: "Gotta Protectors - Amazon's Running Diet", author: 'Ancient Corp', url: 'http://www.ancient.co.jp/~game/download/GottaProtectors_AmazonsRunningDiet.zip', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Gruniozerca', author: 'emunes.pl', url: 'http://emunes.pl/grunio/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Gruniozerca 2', author: null, url: 'http://nesdevcompo.nintendoage.com/contest17/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Hot Seat Harry', author: 'Memblerz', url: 'http://www.nesworld.com/article.php?system=nes&', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'I Wanna Flip the Sky', author: 'TomL', url: 'https://www.neoflash.com/forum/index.php?topic=7472.0_', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Indivisible', author: 'Kasumi', url: 'https://kasumi.itch.io/indivisible', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Lala The Magical', author: null, url: 'http://nesdevcompo.nintendoage.com/contest16/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'LAN Master', author: 'Shiru', url: 'https://shiru.untergrund.net/files/nes/lan_master.zip', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Lawn Mower', author: 'Shiru', url: 'https://shiru.untergrund.net/files/nes/lawn_mower.zip', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Legends of Owlia, The', author: 'Gradual Games', url: 'http://www.gradualgames.com/p/the-legends-of-owlia_1.html', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Lunar Limit', author: null, url: 'https://www.romhacking.net/homebrew/100/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Melo-Jellos 2', author: 'Adrian Makes Games', url: 'https://adrianmakesgames.itch.io/melo-jellos-2', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Miedow', author: 'Mojo Twins', url: 'https://forums.nesdev.com/viewtopic.php?f=33&t=16889', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'MilioNESy', author: null, url: 'http://nesdevcompo.nintendoage.com/contest14/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: "Nebs 'n Debs", author: null, url: 'http://nesdevcompo.nintendoage.com/contest16/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'NES Virus Cleaner', author: null, url: 'https://www.romhacking.net/homebrew/32/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'NeSnake 2', author: null, url: 'https://www.romhacking.net/homebrew/30/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Project Blue', author: null, url: 'http://nesdevcompo.nintendoage.com/contest17/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'SplatooD', author: 'SplatooD Team', url: 'https://www.reddit.com/r/splatoon/comments/3te61d/splatood_a_splatooninspired_demake_for_the_nes/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Streemerz', author: 'Mr. Podunkian', url: 'https://www.fauxgame.com/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Sudoku: NESWORLD Edition', author: 'Al Bailey', url: 'https://www.romhacking.net/homebrew/17/', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Super Bat Puncher', author: 'Morphcat Games', url: 'http://morphcat.de/superbatpuncher', consoleId: 7, systemLabel: 'NES/Famicom' },
+  { title: 'Zooming Secretary', author: 'Shiru', url: 'https://shiru.untergrund.net/files/nes/zooming_secretary.zip', consoleId: 7, systemLabel: 'NES/Famicom' },
+
+  // --- SNES ---
+  { title: 'Christmas Craze', author: 'Shiru', url: 'https://www.romhacking.net/homebrew/89/', consoleId: 3, systemLabel: 'SNES/Super Famicom' },
+  { title: 'Super Boss Gaiden', author: 'superfamicom.org (??)', url: 'https://superbossgaiden.superfamicom.org/', consoleId: 3, systemLabel: 'SNES/Super Famicom' },
+  { title: 'Super Sudoku', author: 'Raphaël Assénat', url: 'https://www.raphnet.net/divers/retro_challenge_2019_03/index_en.php', consoleId: 3, systemLabel: 'SNES/Super Famicom' },
+  { title: 'Super Road Blaster (MSU-1)', author: 'dforce3000', url: 'https://www.zeldix.net/t1448-super-road-blaster', consoleId: 3, systemLabel: 'SNES/Super Famicom' },
+
+  // --- N64 ---
+  { title: 'Pyoro 64', author: 'n64squid', url: 'https://n64squid.com/pyoro-64/', consoleId: 2, systemLabel: 'Nintendo 64' },
+
+  // --- Virtual Boy ---
+  { title: 'BLOX', author: 'KR155E', url: 'https://www.planetvb.com/modules/games/?h001g', consoleId: 28, systemLabel: 'Virtual Boy' },
+  { title: 'Fishbone', author: 'thunderstruck and Virtual_Ben', url: 'https://www.planetvb.com/modules/games/?h078g', consoleId: 28, systemLabel: 'Virtual Boy' },
+  { title: 'Mario Kart: Virtual Cup', author: 'DogP', url: 'https://www.planetvb.com/modules/games/?h044d', consoleId: 28, systemLabel: 'Virtual Boy' },
+  { title: 'Tron', author: 'Alberto Covarrubias', url: 'https://www.planetvb.com/modules/games/?h010g', consoleId: 28, systemLabel: 'Virtual Boy' },
+  { title: 'VB Racing', author: 'M.K.', url: 'https://www.planetvb.com/modules/games/?h045g', consoleId: 28, systemLabel: 'Virtual Boy' },
+];
+
+// { title, author, url, consoleId, systemLabel, host }
+export const FREE_GAMES = RAW_ENTRIES.map((entry) => ({ ...entry, host: hostOf(entry.url) }));
+
+export const FREE_GAMES_BY_CONSOLE = (() => {
+  const map = new Map();
+  for (const entry of FREE_GAMES) {
+    const key = entry.consoleId;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(entry);
+  }
+  return map;
+})();
+
+export function freeGamesForConsole(id) {
+  return FREE_GAMES_BY_CONSOLE.get(id) ?? [];
+}

--- a/server/src/data/frontends.js
+++ b/server/src/data/frontends.js
@@ -1,0 +1,73 @@
+// Platform naming per launcher frontend, keyed by RetroAchievements console id.
+//
+// `esde`      = ES-DE / EmulationStation Desktop Edition system directory name.
+//               Verified against es-de's own resources/systems/windows/es_systems.xml.
+//               ES-DE expects one gamelist.xml per system, stored either in
+//               <ROMs>/<system>/gamelist.xml or ~/ES-DE/gamelists/<system>/.
+// `launchbox` = LaunchBox platform name (its importer matches on this string).
+//
+// Systems ES-DE has no directory for are simply absent — the export then skips
+// them rather than inventing a folder name.
+export const FRONTEND_PLATFORMS = {
+  1:  { esde: 'megadrive',     launchbox: 'Sega Genesis' },
+  2:  { esde: 'n64',           launchbox: 'Nintendo 64' },
+  3:  { esde: 'snes',          launchbox: 'Super Nintendo Entertainment System' },
+  4:  { esde: 'gb',            launchbox: 'Nintendo Game Boy' },
+  5:  { esde: 'gba',           launchbox: 'Nintendo Game Boy Advance' },
+  6:  { esde: 'gbc',           launchbox: 'Nintendo Game Boy Color' },
+  7:  { esde: 'nes',           launchbox: 'Nintendo Entertainment System' },
+  8:  { esde: 'pcengine',      launchbox: 'NEC TurboGrafx-16' },
+  9:  { esde: 'segacd',        launchbox: 'Sega CD' },
+  10: { esde: 'sega32x',       launchbox: 'Sega 32X' },
+  11: { esde: 'mastersystem',  launchbox: 'Sega Master System' },
+  12: { esde: 'psx',           launchbox: 'Sony Playstation' },
+  13: { esde: 'atarilynx',     launchbox: 'Atari Lynx' },
+  14: { esde: 'ngp',           launchbox: 'SNK Neo Geo Pocket' },
+  15: { esde: 'gamegear',      launchbox: 'Sega Game Gear' },
+  16: { esde: 'gc',            launchbox: 'Nintendo GameCube' },
+  17: { esde: 'atarijaguar',   launchbox: 'Atari Jaguar' },
+  18: { esde: 'nds',           launchbox: 'Nintendo DS' },
+  19: { esde: 'wii',           launchbox: 'Nintendo Wii' },
+  21: { esde: 'ps2',           launchbox: 'Sony Playstation 2' },
+  23: { esde: 'odyssey2',      launchbox: 'Magnavox Odyssey 2' },
+  24: { esde: 'pokemini',      launchbox: 'Nintendo Pokemon Mini' },
+  25: { esde: 'atari2600',     launchbox: 'Atari 2600' },
+  27: { esde: 'arcade',        launchbox: 'Arcade' },
+  28: { esde: 'virtualboy',    launchbox: 'Nintendo Virtual Boy' },
+  29: { esde: 'msx',           launchbox: 'Microsoft MSX' },
+  33: { esde: 'sg-1000',       launchbox: 'Sega SG-1000' },
+  37: { esde: 'amstradcpc',    launchbox: 'Amstrad CPC' },
+  38: { esde: 'apple2',        launchbox: 'Apple II' },
+  39: { esde: 'saturn',        launchbox: 'Sega Saturn' },
+  40: { esde: 'dreamcast',     launchbox: 'Sega Dreamcast' },
+  41: { esde: 'psp',           launchbox: 'Sony PSP' },
+  43: { esde: '3do',           launchbox: '3DO Interactive Multiplayer' },
+  44: { esde: 'colecovision',  launchbox: 'ColecoVision' },
+  45: { esde: 'intellivision', launchbox: 'Mattel Intellivision' },
+  46: { esde: 'vectrex',       launchbox: 'GCE Vectrex' },
+  47: { esde: 'pc88',          launchbox: 'NEC PC-8801' },
+  49: { esde: 'pcfx',          launchbox: 'NEC PC-FX' },
+  51: { esde: 'atari7800',     launchbox: 'Atari 7800' },
+  53: { esde: 'wonderswan',    launchbox: 'WonderSwan' },
+  56: { esde: 'neogeocd',      launchbox: 'SNK Neo Geo CD' },
+  57: { esde: 'channelf',      launchbox: 'Fairchild Channel F' },
+  63: { esde: 'supervision',   launchbox: 'Watara Supervision' },
+  69: { esde: 'megaduck',      launchbox: 'Mega Duck' },
+  71: { esde: 'arduboy',       launchbox: 'Arduboy' },
+  72: { esde: 'wasm4',         launchbox: 'WASM-4' },
+  73: { esde: 'arcadia',       launchbox: 'Emerson Arcadia 2001' },
+  74: { esde: null,            launchbox: 'Interton VC 4000' },
+  75: { esde: null,            launchbox: 'Elektor TV Games Computer' },
+  76: { esde: 'pcenginecd',    launchbox: 'NEC TurboGrafx-CD' },
+  77: { esde: 'atarijaguarcd', launchbox: 'Atari Jaguar CD' },
+  78: { esde: 'nds',           launchbox: 'Nintendo DS' },   // ES-DE has no separate DSi system
+  80: { esde: 'uzebox',        launchbox: 'Uzebox' },
+  81: { esde: 'fds',           launchbox: 'Nintendo Famicom Disk System' },
+};
+
+export function esdeSystem(consoleId) {
+  return FRONTEND_PLATFORMS[consoleId]?.esde ?? null;
+}
+export function launchboxPlatform(consoleId, fallback = '') {
+  return FRONTEND_PLATFORMS[consoleId]?.launchbox ?? fallback;
+}

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -642,7 +642,9 @@ export function resetCollection() {
 export function resetHashDb() {
   const counts = wipeTables(['games', 'hashes', 'console_sync']);
   clearApiCache('game:');
-  db.exec('VACUUM');
+  // No synchronous VACUUM here — it can be very slow on a large DB and would
+  // block the reset endpoint. Freed pages go to the freelist and are reclaimed
+  // by the next backup (VACUUM INTO) / checkpoint.
   return counts;
 }
 

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -163,6 +163,36 @@ function addColumn(table, def) {
 addColumn('games', 'title_norm TEXT');
 db.exec('CREATE INDEX IF NOT EXISTS idx_games_title_norm ON games(title_norm)');
 addColumn('library', 'message TEXT'); // persist scan error/skip reason for the collection view
+addColumn('library', 'crc TEXT');     // raw file CRC32 (lowercase hex) for DAT completeness matching
+
+// ---- DAT completeness (No-Intro/Redump/logiqx catalogs) -------------------
+// Imported DAT files + their ROM entries. Matching is by raw-file CRC32 (what
+// DATs universally carry), stored on the library row — this is a different
+// dimension from the RetroAchievements hash (which strips headers etc.).
+db.exec(`
+  CREATE TABLE IF NOT EXISTS dat_files (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT,
+    description  TEXT,
+    version      TEXT,
+    console_id   INTEGER,             -- guessed RA console (nullable)
+    game_count   INTEGER DEFAULT 0,
+    imported_at  INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS dat_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    dat_id     INTEGER NOT NULL,
+    game_name  TEXT,
+    rom_name   TEXT,
+    size       INTEGER,
+    crc        TEXT,                  -- lowercase hex
+    md5        TEXT,
+    sha1       TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_dat_entries_dat ON dat_entries(dat_id);
+  CREATE INDEX IF NOT EXISTS idx_dat_entries_crc ON dat_entries(crc);
+  CREATE INDEX IF NOT EXISTS idx_library_crc ON library(crc);
+`);
 
 // Normalize a title for accent/diacritic-insensitive search:
 // "Pokémon Crystal Version" -> "pokemon crystal version".
@@ -588,6 +618,113 @@ export function libraryStats() {
   return { total, byStatus, byConsole };
 }
 export function clearLibrary() { db.prepare('DELETE FROM library').run(); }
+
+// Destructive resets exposed in Settings → Data. Each returns the row counts it
+// removed so the UI can report what happened. Credentials/settings are never
+// touched here.
+function wipeTables(tables) {
+  const counts = {};
+  for (const tbl of tables) {
+    try {
+      counts[tbl] = db.prepare(`SELECT COUNT(*) AS n FROM ${tbl}`).get().n;
+      db.prepare(`DELETE FROM ${tbl}`).run();
+    } catch { counts[tbl] = 0; }
+  }
+  return counts;
+}
+// Collection + scan history + per-file hash cache. Keeps the synced hash DB and
+// the RA login, so the next scan just re-populates from disk.
+export function resetCollection() {
+  return wipeTables(['library', 'scans', 'scan_items', 'file_hash_cache', 'scan_baseline', 'play_sessions']);
+}
+// The synced RetroAchievements hash database (games/hashes) — forces a fresh
+// sync. Console metadata rows are kept so the systems list still renders.
+export function resetHashDb() {
+  const counts = wipeTables(['games', 'hashes', 'console_sync']);
+  clearApiCache('game:');
+  db.exec('VACUUM');
+  return counts;
+}
+
+// ---- DAT completeness ------------------------------------------------------
+const insertDatFileStmt = db.prepare('INSERT INTO dat_files(name, description, version, console_id, game_count, imported_at) VALUES(?,?,?,?,?,?)');
+const insertDatEntryStmt = db.prepare('INSERT INTO dat_entries(dat_id, game_name, rom_name, size, crc, md5, sha1) VALUES(?,?,?,?,?,?,?)');
+
+// Store a parsed DAT and all its rom entries in one transaction.
+export function insertDat({ name, description, version, console_id, entries }) {
+  const games = new Set();
+  db.exec('BEGIN');
+  try {
+    const info = insertDatFileStmt.run(name || 'DAT', description || null, version || null, console_id ?? null, 0, Date.now());
+    const datId = Number(info.lastInsertRowid);
+    for (const e of entries) {
+      games.add(e.game_name || e.rom_name || '');
+      insertDatEntryStmt.run(datId, e.game_name || null, e.rom_name || null, e.size ?? null,
+        e.crc ? String(e.crc).toLowerCase() : null,
+        e.md5 ? String(e.md5).toLowerCase() : null,
+        e.sha1 ? String(e.sha1).toLowerCase() : null);
+    }
+    db.prepare('UPDATE dat_files SET game_count = ? WHERE id = ?').run(games.size, datId);
+    db.exec('COMMIT');
+    return { id: datId, entries: entries.length, games: games.size };
+  } catch (e) {
+    db.exec('ROLLBACK');
+    throw e;
+  }
+}
+
+// One row per DAT with a live "have" count against the collection's CRC set.
+export function listDats() {
+  const rows = db.prepare('SELECT id, name, description, version, console_id, game_count, imported_at FROM dat_files ORDER BY imported_at DESC').all();
+  const haveStmt = db.prepare(`
+    SELECT COUNT(*) AS n FROM dat_entries e
+    WHERE e.dat_id = ? AND e.crc IS NOT NULL
+      AND e.crc IN (SELECT crc FROM library WHERE crc IS NOT NULL)`);
+  const totalStmt = db.prepare('SELECT COUNT(*) AS n FROM dat_entries WHERE dat_id = ?');
+  return rows.map((r) => ({
+    ...r,
+    total: totalStmt.get(r.id).n,
+    have: haveStmt.get(r.id).n,
+  }));
+}
+
+export function deleteDat(id) {
+  db.prepare('DELETE FROM dat_entries WHERE dat_id = ?').run(id);
+  db.prepare('DELETE FROM dat_files WHERE id = ?').run(id);
+}
+
+// Detailed coverage for one DAT: which rom entries are present in the
+// collection (by CRC) and which are missing.
+export function datCoverage(id, { missingLimit = 5000 } = {}) {
+  const dat = db.prepare('SELECT id, name, description, version, console_id, game_count FROM dat_files WHERE id = ?').get(id);
+  if (!dat) return null;
+  const entries = db.prepare('SELECT game_name, rom_name, size, crc FROM dat_entries WHERE dat_id = ?').all(id);
+  const owned = new Set(db.prepare('SELECT DISTINCT crc FROM library WHERE crc IS NOT NULL').all().map((r) => r.crc));
+  let have = 0;
+  const missing = [];
+  for (const e of entries) {
+    const hit = e.crc && owned.has(e.crc);
+    if (hit) have++;
+    else if (missing.length < missingLimit) missing.push({ game: e.game_name, rom: e.rom_name, crc: e.crc, size: e.size });
+  }
+  return { dat, total: entries.length, have, missing, missingTotal: entries.length - have, collectionCrcCount: owned.size };
+}
+
+// Progress of the raw-CRC pass over the collection (needed before matching).
+export function datCrcStatus() {
+  const total = db.prepare("SELECT COUNT(*) AS n FROM library WHERE status IN ('match','no_match')").get().n;
+  const withCrc = db.prepare("SELECT COUNT(*) AS n FROM library WHERE crc IS NOT NULL").get().n;
+  return { total, withCrc, without: Math.max(0, total - withCrc) };
+}
+
+// Library rows still lacking a raw CRC (candidates for the CRC pass). Only rows
+// that represent a real ROM (match/no_match) — skip errors/skips/rahasher.
+export function getLibraryRowsWithoutCrc(limit = 100000) {
+  return db.prepare("SELECT path, inner_path, size, ext FROM library WHERE crc IS NULL AND status IN ('match','no_match') ORDER BY path LIMIT ?").all(limit);
+}
+export function setLibraryCrc(path, inner, crc) {
+  db.prepare('UPDATE library SET crc = ? WHERE path = ? AND inner_path = ?').run(crc, path, inner ?? '');
+}
 
 // Distinct on-disk file paths in the collection (one archive may back many
 // rows via inner_path). Used by the health check to test file existence.

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -280,11 +280,21 @@ export async function registerRoutes(app) {
   // Powers the footer "update available" chip. The Electron shell does the real
   // download/install via electron-updater; the web/.bat build just links out.
   let updateCache = null;
+  // Compare version cores (major.minor.patch); on a tie a build WITHOUT a
+  // prerelease tag is newer than the same core WITH one (1.0.0 > 1.0.0-rc.1).
+  // Build metadata (+…) is ignored. Good enough for GitHub release tags without
+  // pulling in a full semver dependency.
   const semverGt = (a, b) => {
-    const pa = String(a).split(/[.\-+]/).map((n) => parseInt(n, 10) || 0);
-    const pb = String(b).split(/[.\-+]/).map((n) => parseInt(n, 10) || 0);
-    for (let i = 0; i < Math.max(pa.length, pb.length); i++) { const d = (pa[i] || 0) - (pb[i] || 0); if (d) return d > 0; }
-    return false;
+    const parse = (v) => {
+      const [core, pre = ''] = String(v).replace(/^v/i, '').split('+')[0].split('-');
+      return { nums: core.split('.').map((n) => parseInt(n, 10) || 0), pre };
+    };
+    const A = parse(a); const B = parse(b);
+    for (let i = 0; i < 3; i++) { const d = (A.nums[i] || 0) - (B.nums[i] || 0); if (d) return d > 0; }
+    if (A.pre === B.pre) return false;
+    if (!A.pre) return true;    // a = release, b = prerelease of the same core
+    if (!B.pre) return false;   // b = release → a (prerelease) is not newer
+    return A.pre > B.pre;       // both prereleases → lexical fallback
   };
   const pickInstaller = (assets) => {
     if (!Array.isArray(assets)) return null;

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -10,7 +10,8 @@ import { config, ROOT } from './config.js';
 import {
   getConsoles, getSyncState, getScan, listScans, getScanItems,
   createScan, finishScan, totalHashCount, totalGameCount, getSetting, setSetting,
-  getLibrary, libraryStats, clearLibrary, getGamesByConsole, countGamesByConsole,
+  getLibrary, libraryStats, clearLibrary, resetCollection, resetHashDb, getGamesByConsole, countGamesByConsole,
+  insertDat, listDats, deleteDat, datCoverage, datCrcStatus, getLibraryRowsWithoutCrc, setLibraryCrc,
   searchGames, getDuplicates, getDuplicateFiles, libraryInsights, suggestPlayable,
   getPlayableGames,
   getApiCache, setApiCache, clearApiCache, getCacheTtls, setCacheTtls,
@@ -42,6 +43,8 @@ import { setScheduleConfig, scheduleStatus } from './scheduler.js';
 import { acquireScanLock, releaseScanLock, scanLockHolder } from './scan-lock.js';
 import { CONSOLE_BY_ID } from './consoles.js';
 import { statSync, readdirSync, readFileSync } from 'node:fs';
+import { parseDat, guessConsole, crc32File, crc32ZipEntry } from './dat.js';
+import { extname as extnameFn } from 'node:path';
 
 // Single version source = root package.json (web/src/lib/version.ts mirrors it).
 const APP_VERSION = (() => {
@@ -273,6 +276,45 @@ export async function registerRoutes(app) {
   // ---- status / meta ------------------------------------------------------
   app.get('/api/health', async () => ({ ok: true, version: APP_VERSION }));
 
+  // ---- update check (GitHub latest release) -------------------------------
+  // Powers the footer "update available" chip. The Electron shell does the real
+  // download/install via electron-updater; the web/.bat build just links out.
+  let updateCache = null;
+  const semverGt = (a, b) => {
+    const pa = String(a).split(/[.\-+]/).map((n) => parseInt(n, 10) || 0);
+    const pb = String(b).split(/[.\-+]/).map((n) => parseInt(n, 10) || 0);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) { const d = (pa[i] || 0) - (pb[i] || 0); if (d) return d > 0; }
+    return false;
+  };
+  const pickInstaller = (assets) => {
+    if (!Array.isArray(assets)) return null;
+    const exes = assets.filter((a) => /\.exe$/i.test(a.name));
+    const setup = exes.find((a) => /setup/i.test(a.name)) || exes[0];
+    return setup ? { name: setup.name, url: setup.browser_download_url, size: setup.size } : null;
+  };
+  app.get('/api/update/check', async (req) => {
+    const fresh = req.query.fresh === '1';
+    if (!fresh && updateCache && Date.now() - updateCache.at < 60 * 60 * 1000) return updateCache.value;
+    try {
+      const res = await fetch('https://api.github.com/repos/x3kim/RAChecker/releases/latest', {
+        headers: { accept: 'application/vnd.github+json', 'user-agent': 'RAChecker' },
+        signal: AbortSignal.timeout(6000),
+      });
+      if (!res.ok) throw new Error('GitHub HTTP ' + res.status);
+      const j = await res.json();
+      const latest = String(j.tag_name || '').replace(/^v/i, '');
+      const value = {
+        ok: true, current: APP_VERSION, latest,
+        newer: latest ? semverGt(latest, APP_VERSION) : false,
+        url: j.html_url, notes: String(j.body || '').slice(0, 4000), asset: pickInstaller(j.assets),
+      };
+      updateCache = { at: Date.now(), value };
+      return value;
+    } catch (e) {
+      return { ok: false, current: APP_VERSION, error: String(e.message) };
+    }
+  });
+
   app.get('/api/status', async () => {
     const consoles = getConsoles();
     const sync = getSyncState();
@@ -329,7 +371,7 @@ export async function registerRoutes(app) {
     raUsername: config.raUsername,
     cacheTtls: getCacheTtls(),
     scanFileTimeoutSec: Number(getSetting('scanFileTimeoutSec', 600)),
-    scanConcurrency: Math.max(1, Math.min(16, Number(getSetting('scanConcurrency', 4)) || 4)),
+    scanConcurrency: Math.max(1, Math.min(16, Number(getSetting('scanConcurrency', 1)) || 1)),
     enabledConsoles: getEnabledConsoles(),
     bigFileCopy: config.bigFileCopy,
     rateLimit: config.rateLimit,
@@ -346,7 +388,7 @@ export async function registerRoutes(app) {
       setSetting('scanFileTimeoutSec', Math.max(10, Number(body.scanFileTimeoutSec) || 600));
     }
     if (body.scanConcurrency != null) {
-      setSetting('scanConcurrency', Math.max(1, Math.min(16, Number(body.scanConcurrency) || 4)));
+      setSetting('scanConcurrency', Math.max(1, Math.min(16, Number(body.scanConcurrency) || 1)));
     }
     // "Systems I care about": array of console ids, or null/[] to mean "all".
     if ('enabledConsoles' in body) {
@@ -456,6 +498,43 @@ export async function registerRoutes(app) {
     }
     storageCache = null; // reflect freed space immediately
     return { ok: true, removed, freed };
+  });
+
+  // Delete the local image cache (badges/box art). Fully re-downloadable via a
+  // re-open or the badge pre-cache; does not touch the database.
+  app.post('/api/data/clear-images', async () => {
+    let entries;
+    try { entries = readdirSync(config.imageCacheDir, { withFileTypes: true }); }
+    catch { return { ok: true, removed: 0, freed: 0 }; }
+    let removed = 0; let freed = 0;
+    for (const e of entries) {
+      const full = join(config.imageCacheDir, e.name);
+      try {
+        const sz = e.isDirectory() ? dirSize(full) : statSync(full).size;
+        await rm(full, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        removed++; freed += sz;
+      } catch { /* in use — skip */ }
+    }
+    storageCache = null;
+    return { ok: true, removed, freed };
+  });
+
+  // Wipe the collection + scan history + per-file hash cache (keeps the synced
+  // hash DB and the RA login). Refused mid-scan.
+  app.post('/api/data/reset-collection', async () => {
+    if (activeScan) return { ok: false, error: 'Während eines Scans nicht möglich.' };
+    const counts = resetCollection();
+    storageCache = null;
+    return { ok: true, counts };
+  });
+
+  // Wipe the synced RetroAchievements hash database (forces a fresh sync next
+  // time). Keeps the RA login and console metadata. Refused mid-scan.
+  app.post('/api/data/reset-hashdb', async () => {
+    if (activeScan) return { ok: false, error: 'Während eines Scans nicht möglich.' };
+    const counts = resetHashDb();
+    storageCache = null;
+    return { ok: true, counts };
   });
 
   // ---- database backups ---------------------------------------------------
@@ -598,7 +677,7 @@ export async function registerRoutes(app) {
       bigFileMaxBytes: bigFileMaxBytes(),
       emit: (ev, data) => send(ev, data),
     });
-    const concurrency = Number(req.query.concurrency) || Math.max(1, Math.min(16, Number(getSetting('scanConcurrency', 4)) || 4));
+    const concurrency = Number(req.query.concurrency) || Math.max(1, Math.min(16, Number(getSetting('scanConcurrency', 1)) || 1));
     scanner.run({ concurrency })
       .then((r) => finishScan(scanId, r.status, { totals: r.totals, bySystem: r.bySystem }, Date.now()))
       .catch((e) => { send('error', { message: String(e.message) }); finishScan(scanId, 'error', { error: String(e.message) }, Date.now()); })
@@ -922,6 +1001,79 @@ export async function registerRoutes(app) {
     } finally {
       await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 120 }).catch(() => {});
     }
+  });
+
+  // ---- DAT completeness (No-Intro/Redump/logiqx catalogs) -----------------
+  // Import DAT files, then match them against the collection by raw CRC32 —
+  // "which of this curated set do I have / am I missing", RomVault-style.
+  app.post('/api/dat/import', async (req) => {
+    const imported = [];
+    const errors = [];
+    for await (const part of req.parts()) {
+      if (part.type !== 'file') continue;
+      const fname = basename(part.filename || 'dat.dat');
+      try {
+        const buf = await part.toBuffer();
+        const { header, entries } = parseDat(buf.toString('utf8'));
+        if (!entries.length) { errors.push({ file: fname, error: 'no ROM entries found' }); continue; }
+        const name = (header.name || header.description || fname).trim();
+        const consoleId = guessConsole(name) ?? guessConsole(header.description);
+        const r = insertDat({ name, description: header.description, version: header.version, console_id: consoleId, entries });
+        imported.push({ file: fname, name, console_id: consoleId, ...r });
+      } catch (e) {
+        errors.push({ file: fname, error: String(e.message).slice(0, 200) });
+      }
+    }
+    return { ok: errors.length === 0, imported, errors };
+  });
+
+  app.get('/api/dat/list', async () => {
+    const dats = listDats().map((d) => ({ ...d, console_name: d.console_id != null ? (CONSOLE_BY_ID.get(d.console_id)?.name || null) : null }));
+    return { dats, crc: datCrcStatus() };
+  });
+
+  app.get('/api/dat/crc-status', async () => datCrcStatus());
+
+  app.get('/api/dat/:id/coverage', async (req) => {
+    const cov = datCoverage(Number(req.params.id));
+    if (!cov) return { error: 'not found' };
+    return { ...cov, console_name: cov.dat.console_id != null ? (CONSOLE_BY_ID.get(cov.dat.console_id)?.name || null) : null };
+  });
+
+  app.delete('/api/dat/:id', async (req) => { deleteDat(Number(req.params.id)); return { ok: true }; });
+
+  // Compute raw CRC32 for collection files that don't have one yet (required
+  // before matching). ZIP members read their CRC from the central directory
+  // (cheap, no decompression); loose files stream. 7z/rar members are skipped
+  // in this pass. SSE progress.
+  app.get('/api/dat/scan-crc/stream', (req, reply) => {
+    const { send, close } = openSSE(req, reply);
+    let closed = false;
+    req.raw.on('close', () => { closed = true; });
+    (async () => {
+      const rows = getLibraryRowsWithoutCrc();
+      send('init', { total: rows.length });
+      let done = 0; let computed = 0; let skipped = 0;
+      for (const row of rows) {
+        if (closed) break;
+        const inner = row.inner_path || '';
+        const archExt = extnameFn(row.path).toLowerCase();
+        try {
+          let crc = null;
+          if (inner) {
+            if (archExt === '.zip') crc = await crc32ZipEntry(row.path, inner);
+            else skipped++; // 7z/rar members not covered in this pass
+          } else {
+            crc = await crc32File(row.path);
+          }
+          if (crc) { setLibraryCrc(row.path, inner, crc); computed++; }
+        } catch { skipped++; }
+        done++;
+        if ((done & 15) === 0 || done === rows.length) send('progress', { done, total: rows.length, computed, skipped });
+      }
+      send('done', { done, computed, skipped, ...datCrcStatus() });
+      close();
+    })().catch(() => { try { close(); } catch { /* already closed */ } });
   });
 
   // ---- duplicates (1G1R helper) -------------------------------------------

--- a/server/src/scheduler.js
+++ b/server/src/scheduler.js
@@ -56,7 +56,7 @@ async function tick() {
   setSetting('scheduleLastRunDay', dayKey(now)); // claim the slot before the (long) scan
   try {
     try { snapshotLibraryBaseline(); } catch { /* diff just won't update */ }
-    const concurrency = Math.max(1, Math.min(16, Number(getSetting('scanConcurrency', 4)) || 4));
+    const concurrency = Math.max(1, Math.min(16, Number(getSetting('scanConcurrency', 1)) || 1));
     const scanner = new Scanner({ rootPath: root, scanId: null, ...scannerOpts() });
     await scanner.run({ concurrency });
     setSetting('scheduleLastRunAt', Date.now());

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de" class="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker-web",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,15 +3,18 @@ import type { ComponentType } from 'react';
 import {
   Gamepad2, LayoutDashboard, ScanLine, DatabaseZap, Settings as SettingsIcon,
   Cpu, HardDriveDownload, Trophy, Palette, Check, Eye, UploadCloud, Keyboard, Languages, History, Compass,
-  Sparkles, MoreHorizontal,
+  Sparkles, MoreHorizontal, ClipboardList,
 } from 'lucide-react';
 import { api } from './lib/api';
 import type { AppStatus, ScanItem } from './lib/api';
 import { visibleThemes, loadTheme, applyTheme, loadFont, applyFont, loadAurora, applyAurora } from './lib/theme';
 import { applyCrt, loadCrt } from './lib/crt';
 import { ViewFade } from './lib/anim';
-import { useI18n, LANGS } from './lib/i18n';
+import { useI18n, LANGS, langChosen } from './lib/i18n';
 import type { Lang } from './lib/i18n';
+import { LanguageGate } from './components/LanguageGate';
+import { Flag } from './components/Flag';
+import { UpdateChip } from './components/UpdateChip';
 import { APP_VERSION, REPO_URL } from './lib/version';
 import { collectDroppedFiles } from './lib/drop';
 import { JobsProvider } from './lib/jobs';
@@ -35,9 +38,10 @@ import { WatchToasts } from './components/WatchToasts';
 import { JobHud } from './components/JobHud';
 import { GuidedTour } from './components/GuidedTour';
 import { DiscoverView } from './components/DiscoverView';
+import { DatView } from './components/DatView';
 import { EmulatorSetupModal } from './components/EmulatorSetupModal';
 
-type Tab = 'dashboard' | 'scan' | 'library' | 'games' | 'discover' | 'insights' | 'mastery' | 'hardcore' | 'sync' | 'settings';
+type Tab = 'dashboard' | 'scan' | 'library' | 'games' | 'discover' | 'insights' | 'mastery' | 'hardcore' | 'sync' | 'dat' | 'settings';
 
 // "Mastery" is intentionally NOT listed here — it's reached via the profile
 // button on the right, so listing it again would duplicate the entry point.
@@ -49,13 +53,14 @@ const TABS: { id: Tab; labelKey: string; icon: ComponentType<any> }[] = [
   { id: 'games', labelKey: 'nav.games', icon: Trophy },
   { id: 'discover', labelKey: 'nav.discover', icon: Sparkles },
   { id: 'sync', labelKey: 'nav.sync', icon: DatabaseZap },
+  { id: 'dat', labelKey: 'nav.dat', icon: ClipboardList },
 ];
 
 const PROFILE_TABS: Tab[] = ['mastery', 'library', 'insights', 'hardcore'];
 
 // g-prefixed navigation shortcuts (press g, then the key).
 const NAV_KEYS: Record<string, Tab> = {
-  d: 'dashboard', s: 'scan', g: 'games', e: 'discover', h: 'sync', p: 'mastery', ',': 'settings',
+  d: 'dashboard', s: 'scan', g: 'games', e: 'discover', h: 'sync', t: 'dat', p: 'mastery', ',': 'settings',
 };
 
 export function App() {
@@ -74,6 +79,8 @@ export function App() {
   const [showPalette, setShowPalette] = useState(false);
   const [showTour, setShowTour] = useState(false);
   const [showEmuSetup, setShowEmuSetup] = useState(false);
+  // First-run language picker: shown until the user has ever chosen a language.
+  const [langGate, setLangGate] = useState(() => !langChosen());
   const emuChecked = useRef(false);
   const dragDepth = useRef(0);
 
@@ -197,6 +204,7 @@ export function App() {
                 goScan={() => setTab('scan')} onFindVersion={onFindVersion} />
             )}
             {tab === 'sync' && <SyncView status={status} />}
+            {tab === 'dat' && <DatView />}
             {tab === 'settings' && <Settings status={status} refresh={refresh} onAuthChange={reloadProfile} theme={theme} changeTheme={changeTheme} />}
           </ViewFade>
         </main>
@@ -206,6 +214,7 @@ export function App() {
             <button data-tour="version" className="hover:text-neon-cyan transition-colors" onClick={() => setShowChangelog(true)} title={t('footer.changelog')}>
               RACHECKER v{APP_VERSION}
             </button>
+            <UpdateChip />
             <a href={REPO_URL} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 hover:text-neon-cyan transition-colors" title="GitHub">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.7 5.4-5.28 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5Z"/></svg>
               GitHub
@@ -231,6 +240,7 @@ export function App() {
         {showChangelog && <ChangelogModal onClose={() => setShowChangelog(false)} />}
         {showShortcuts && <ShortcutsModal onClose={() => setShowShortcuts(false)} />}
         {showTour && <GuidedTour onClose={() => setShowTour(false)} />}
+        {langGate && <LanguageGate onChosen={() => setLangGate(false)} />}
         {showWizard && <OnboardingWizard status={status} refresh={refresh} onAuthChange={reloadProfile} onClose={dismissWizard} />}
         {showEmuSetup && <EmulatorSetupModal onClose={() => setShowEmuSetup(false)} goSettings={() => setTab('settings')} />}
         {showPalette && <CommandPalette commands={commands} onOpenGame={setOpenGame} onClose={() => setShowPalette(false)} />}
@@ -336,7 +346,7 @@ function MoreMenu({ onTour, onShortcuts }: { onTour: () => void; onShortcuts: ()
           <div className="px-2.5 pt-1 pb-1 font-mono text-sm text-ink-dim">{t('nav.language')}</div>
           {LANGS.map((l) => (
             <button key={l.id} onClick={() => setLang(l.id as Lang)} className={item}>
-              <span className="text-base">{l.flag}</span>
+              <Flag lang={l.id as Lang} />
               <span className="font-body text-sm flex-1 text-ink-hi">{l.name}</span>
               {lang === l.id && <Check size={15} className="text-neon-green" />}
             </button>

--- a/web/src/components/DatView.tsx
+++ b/web/src/components/DatView.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef, useState } from 'react';
+import { ClipboardList, Upload, Trash2, RefreshCw, ChevronRight, Download, X, Search, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { api } from '../lib/api';
+import type { DatFile, CrcStatus, DatCoverage } from '../lib/api';
+import { useI18n } from '../lib/i18n';
+import { fmtBytes, fmtDate } from '../lib/util';
+
+type CrcScan = { active: boolean; done: number; total: number; computed: number; skipped: number };
+
+export function DatView() {
+  const { t } = useI18n();
+  const [dats, setDats] = useState<DatFile[]>([]);
+  const [crc, setCrc] = useState<CrcStatus | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importMsg, setImportMsg] = useState('');
+  const [crcScan, setCrcScan] = useState<CrcScan | null>(null);
+  const [coverage, setCoverage] = useState<DatCoverage | null>(null);
+  const [covLoading, setCovLoading] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  const load = async () => {
+    try { const r = await api.datList(); setDats(r.dats); setCrc(r.crc); } catch { /* ignore */ }
+  };
+  useEffect(() => { load(); return () => { esRef.current?.close(); }; }, []);
+
+  const onFiles = async (files: FileList | null) => {
+    if (!files || !files.length) return;
+    setImporting(true); setImportMsg('');
+    try {
+      const r = await api.datImport(Array.from(files));
+      const games = r.imported.reduce((n, d) => n + (d.games || 0), 0);
+      setImportMsg(r.imported.length
+        ? t('dat.importDone', { n: r.imported.length, games })
+        : (r.errors[0]?.error ? `${t('dat.importErr')}: ${r.errors[0].error}` : t('dat.importErr')));
+      await load();
+    } catch { setImportMsg(t('dat.importErr')); }
+    finally { setImporting(false); if (fileInput.current) fileInput.current.value = ''; setTimeout(() => setImportMsg(''), 8000); }
+  };
+
+  const runCrc = () => {
+    if (crcScan?.active) return;
+    esRef.current?.close();
+    const es = new EventSource('/api/dat/scan-crc/stream');
+    esRef.current = es;
+    setCrcScan({ active: true, done: 0, total: 0, computed: 0, skipped: 0 });
+    const upd = (e: Event, patch: (d: any) => Partial<CrcScan>) => {
+      try { const d = JSON.parse((e as MessageEvent).data); setCrcScan((s) => s ? { ...s, ...patch(d) } : s); } catch { /* ignore */ }
+    };
+    es.addEventListener('init', (e) => upd(e, (d) => ({ total: d.total })));
+    es.addEventListener('progress', (e) => upd(e, (d) => ({ done: d.done, total: d.total, computed: d.computed, skipped: d.skipped })));
+    es.addEventListener('done', (e) => { upd(e, (d) => ({ active: false, done: d.done, computed: d.computed, skipped: d.skipped })); es.close(); load(); });
+    es.onerror = () => { es.close(); setCrcScan((s) => (s ? { ...s, active: false } : null)); };
+  };
+
+  const openCoverage = async (id: number) => {
+    setCovLoading(true); setCoverage(null);
+    try { setCoverage(await api.datCoverage(id)); } catch { /* ignore */ }
+    finally { setCovLoading(false); }
+  };
+
+  const delDat = async (d: DatFile) => {
+    if (!window.confirm(t('dat.deleteConfirm', { name: d.name }))) return;
+    try { await api.datDelete(d.id); if (coverage?.dat.id === d.id) setCoverage(null); await load(); } catch { /* ignore */ }
+  };
+
+  return (
+    <div className="w-full max-w-[1320px] mx-auto flex flex-col gap-5">
+      {/* header */}
+      <div>
+        <h1 className="font-display text-base text-glow-cyan flex items-center gap-2"><ClipboardList size={18} /> {t('dat.title')}</h1>
+        <p className="font-body text-ink-mid mt-2 text-sm leading-relaxed max-w-3xl">{t('dat.intro')}</p>
+      </div>
+
+      {/* import + CRC pass */}
+      <section className="panel p-5 flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <div className="font-display text-sm text-ink-hi flex items-center gap-2"><Upload size={15} className="text-neon-cyan" /> {t('dat.import')}</div>
+          <p className="font-body text-ink-dim text-sm leading-relaxed">{t('dat.importHint')}</p>
+          <div className="flex items-center gap-3 flex-wrap">
+            <input ref={fileInput} type="file" accept=".dat,.xml" multiple className="hidden" onChange={(e) => onFiles(e.target.files)} />
+            <button className="btn btn-primary" onClick={() => fileInput.current?.click()} disabled={importing}>
+              <Upload size={16} className={importing ? 'animate-pulse' : ''} /> {importing ? t('dat.importing') : t('dat.import')}
+            </button>
+            {importMsg && <span className="font-mono text-base text-ink-mid">{importMsg}</span>}
+          </div>
+        </div>
+
+        <div className="pt-4 border-t border-crt-line flex flex-col gap-2">
+          <div className="font-display text-sm text-ink-hi flex items-center gap-2"><RefreshCw size={15} className="text-neon-green" /> {t('dat.crcTitle')}</div>
+          <p className="font-body text-ink-dim text-sm leading-relaxed">{t('dat.crcNote')}</p>
+          {crc && (
+            <div className="font-mono text-base text-ink-mid">
+              {t('dat.crcStatus', { have: crc.withCrc.toLocaleString(), total: crc.total.toLocaleString() })}
+            </div>
+          )}
+          {crcScan?.active && (
+            <div className="flex flex-col gap-1">
+              <div className="progress-track h-2"><div className="progress-fill" style={{ width: `${crcScan.total ? Math.round((crcScan.done / crcScan.total) * 100) : 4}%` }} /></div>
+              <div className="font-mono text-sm text-ink-dim">{t('dat.crcProgress', { done: crcScan.done, total: crcScan.total })}</div>
+            </div>
+          )}
+          {crcScan && !crcScan.active && crcScan.done > 0 && (
+            <div className="font-mono text-sm text-neon-green">{t('dat.crcDone', { computed: crcScan.computed, skipped: crcScan.skipped })}</div>
+          )}
+          <div>
+            <button className="btn" onClick={runCrc} disabled={crcScan?.active || (crc?.without ?? 0) === 0}>
+              <RefreshCw size={16} className={crcScan?.active ? 'animate-spin' : ''} /> {crcScan?.active ? t('dat.crcRunning') : t('dat.crcRun')}
+            </button>
+            {crc && crc.without === 0 && crc.total > 0 && <span className="ml-2 font-mono text-sm text-neon-green inline-flex items-center gap-1"><CheckCircle2 size={13} /> {t('dat.crcAll')}</span>}
+          </div>
+        </div>
+      </section>
+
+      {/* imported DATs */}
+      {dats.length === 0 ? (
+        <div className="panel p-6 text-center font-mono text-base text-ink-dim">{t('dat.empty')}</div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {dats.map((d) => {
+            const pct = d.total ? Math.round((d.have / d.total) * 100) : 0;
+            return (
+              <div key={d.id} className="panel p-4 flex items-center gap-4 flex-wrap">
+                <div className="min-w-0 flex-1">
+                  <div className="font-body text-sm text-ink-hi truncate" title={d.name}>{d.name}</div>
+                  <div className="font-mono text-sm text-ink-dim flex gap-2 flex-wrap">
+                    {d.console_name && <span>{d.console_name}</span>}
+                    <span>{t('dat.games', { n: d.game_count.toLocaleString() })}</span>
+                    <span>· {fmtDate(d.imported_at)}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <div className="text-right">
+                    <div className="font-display text-sm" style={{ color: pct >= 100 ? 'var(--color-neon-green)' : 'var(--color-neon-cyan)' }}>{pct}%</div>
+                    <div className="font-mono text-sm text-ink-dim">{d.have.toLocaleString()} / {d.total.toLocaleString()}</div>
+                  </div>
+                  <div className="w-28 progress-track h-2 hidden sm:block"><div className="progress-fill" style={{ width: `${pct}%` }} /></div>
+                  <button className="btn !py-1.5 !px-3 text-sm" onClick={() => openCoverage(d.id)}>{t('dat.details')} <ChevronRight size={14} /></button>
+                  <button className="btn btn-danger !py-1.5 !px-2 text-sm" onClick={() => delDat(d)} title={t('dat.delete')}><Trash2 size={14} /></button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {(coverage || covLoading) && <CoverageModal coverage={coverage} loading={covLoading} onClose={() => setCoverage(null)} />}
+    </div>
+  );
+}
+
+function CoverageModal({ coverage, loading, onClose }: { coverage: DatCoverage | null; loading: boolean; onClose: () => void }) {
+  const { t } = useI18n();
+  const [q, setQ] = useState('');
+  const missing = coverage?.missing ?? [];
+  const filtered = q.trim()
+    ? missing.filter((m) => (m.game || '').toLowerCase().includes(q.toLowerCase()) || (m.rom || '').toLowerCase().includes(q.toLowerCase()))
+    : missing;
+
+  const exportMissing = () => {
+    if (!coverage) return;
+    const lines = missing.map((m) => m.rom || m.game || m.crc || '').filter(Boolean);
+    const blob = new Blob([lines.join('\r\n') + '\r\n'], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `${(coverage.dat.name || 'dat').replace(/[^\w.-]+/g, '_')}-missing.txt`;
+    a.click(); URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[70] grid place-items-center p-4" style={{ background: 'rgba(4,6,12,.82)', backdropFilter: 'blur(5px)' }} onClick={onClose}>
+      <div className="panel panel-glow modal-pop w-full max-w-3xl max-h-[88vh] flex flex-col overflow-hidden" onClick={(e) => e.stopPropagation()}>
+        <div className="p-4 border-b border-crt-line flex items-center gap-3 sticky-head">
+          <div className="min-w-0 flex-1">
+            <h2 className="font-display text-sm text-glow-cyan truncate">{coverage?.dat.name || '…'}</h2>
+            {coverage && (
+              <div className="font-mono text-sm text-ink-dim">
+                {t('dat.cov.have', { have: coverage.have, total: coverage.total })} · {t('dat.cov.missing', { n: coverage.missingTotal })}
+              </div>
+            )}
+          </div>
+          <button className="btn !p-1.5" onClick={onClose}><X size={16} /></button>
+        </div>
+
+        {loading ? (
+          <div className="p-8 text-center font-mono text-base text-ink-dim">…</div>
+        ) : coverage && (
+          <>
+            {coverage.collectionCrcCount === 0 && (
+              <div className="m-4 p-3 rounded-lg font-mono text-sm flex items-start gap-2" style={{ background: 'rgba(255,180,0,.08)', color: 'var(--color-neon-amber)' }}>
+                <AlertTriangle size={15} className="shrink-0 mt-0.5" /> {t('dat.cov.crcWarn')}
+              </div>
+            )}
+            <div className="px-4 pt-3 flex items-center gap-2">
+              <div className="relative flex-1">
+                <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-dim" />
+                <input className="input !pl-8 w-full" placeholder={t('dat.cov.searchMissing')} value={q} onChange={(e) => setQ(e.target.value)} />
+              </div>
+              <button className="btn !py-1.5 !px-3 text-sm shrink-0" onClick={exportMissing} disabled={!missing.length}><Download size={14} /> {t('dat.cov.export')}</button>
+            </div>
+            <div className="p-4 overflow-auto flex-1">
+              {filtered.length === 0 ? (
+                <div className="text-center font-mono text-base text-neon-green py-6 flex items-center justify-center gap-2"><CheckCircle2 size={16} /> {t('dat.cov.noMissing')}</div>
+              ) : (
+                <div className="flex flex-col gap-1">
+                  {filtered.map((m, i) => (
+                    <div key={i} className="flex items-center gap-3 font-mono text-sm panel !rounded-lg px-3 py-1.5">
+                      <span className="text-ink-hi truncate flex-1 min-w-0" title={m.rom || m.game || ''}>{m.rom || m.game || '—'}</span>
+                      {m.crc && <span className="text-ink-dim shrink-0 hidden sm:inline">{m.crc}</span>}
+                      {m.size != null && <span className="text-ink-dim shrink-0">{fmtBytes(m.size)}</span>}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Flag.tsx
+++ b/web/src/components/Flag.tsx
@@ -1,0 +1,39 @@
+import { useId } from 'react';
+import type { Lang } from '../lib/i18n';
+
+// Inline SVG flags. Emoji regional-indicator flags (🇩🇪/🇬🇧) do NOT render as
+// flags on Windows (they show "DE"/"GB" letters), so we draw them ourselves.
+export function Flag({ lang, size = 22, className = '' }: { lang: Lang; size?: number; className?: string }) {
+  const w = size;
+  const h = Math.round(size * 0.64);
+  const box: React.CSSProperties = { display: 'inline-block', borderRadius: 3, boxShadow: '0 0 0 1px rgba(0,0,0,.25)' };
+
+  if (lang === 'de') {
+    return (
+      <svg viewBox="0 0 5 3" width={w} height={h} className={className} style={box} aria-hidden="true">
+        <rect width="5" height="3" fill="#000000" />
+        <rect width="5" height="2" y="1" fill="#DD0000" />
+        <rect width="5" height="1" y="2" fill="#FFCE00" />
+      </svg>
+    );
+  }
+
+  // 'en' → Union Jack (GB). clipPath ids must be unique per render instance,
+  // else a second flag on the page clips against the first one's paths.
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const s = `s${uid}`;
+  const t = `t${uid}`;
+  return (
+    <svg viewBox="0 0 60 30" width={w} height={h} className={className} style={box} aria-hidden="true">
+      <clipPath id={s}><path d="M0,0 v30 h60 v-30 z" /></clipPath>
+      <clipPath id={t}><path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z" /></clipPath>
+      <g clipPath={`url(#${s})`}>
+        <path d="M0,0 v30 h60 v-30 z" fill="#012169" />
+        <path d="M0,0 L60,30 M60,0 L0,30" stroke="#ffffff" strokeWidth="6" />
+        <path d="M0,0 L60,30 M60,0 L0,30" clipPath={`url(#${t})`} stroke="#C8102E" strokeWidth="4" />
+        <path d="M30,0 v30 M0,15 h60" stroke="#ffffff" strokeWidth="10" />
+        <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" strokeWidth="6" />
+      </g>
+    </svg>
+  );
+}

--- a/web/src/components/LanguageGate.tsx
+++ b/web/src/components/LanguageGate.tsx
@@ -1,0 +1,34 @@
+import { Gamepad2 } from 'lucide-react';
+import { LANGS, useI18n } from '../lib/i18n';
+import type { Lang } from '../lib/i18n';
+import { Flag } from './Flag';
+
+// First-run language picker. Shown once, before the onboarding wizard, when the
+// user has never explicitly chosen a language. Picking one persists it (via
+// setLang) so it never reappears.
+export function LanguageGate({ onChosen }: { onChosen: () => void }) {
+  const { setLang } = useI18n();
+  const pick = (l: Lang) => { setLang(l); onChosen(); };
+  return (
+    <div className="fixed inset-0 z-[95] grid place-items-center p-4" style={{ background: 'rgba(4,6,12,.92)', backdropFilter: 'blur(6px)' }}>
+      <div className="panel panel-glow modal-pop w-full max-w-md text-center p-7 crt-scanlines relative overflow-hidden">
+        <div className="relative z-10">
+          <span className="grid place-items-center rounded-xl mx-auto mb-4" style={{ width: 52, height: 52, background: 'linear-gradient(180deg,rgba(34,224,255,.25),rgba(157,107,255,.12))', border: '1px solid var(--color-neon-cyan)', boxShadow: 'var(--shadow-glow-cyan)' }}>
+            <Gamepad2 size={26} className="text-neon-cyan" />
+          </span>
+          <h1 className="font-display text-base text-glow-cyan">RACHECKER</h1>
+          <p className="font-mono text-base text-ink-dim mt-2">Choose your language · Sprache wählen</p>
+          <div className="grid grid-cols-2 gap-3 mt-5">
+            {LANGS.map((l) => (
+              <button key={l.id} onClick={() => pick(l.id as Lang)}
+                className="btn flex-col !py-4 gap-2 items-center hover:border-neon-cyan">
+                <Flag lang={l.id as Lang} size={44} />
+                <span className="font-body text-sm text-ink-hi">{l.name}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -127,7 +127,7 @@ export function Settings({ status, refresh, onAuthChange, theme, changeTheme }: 
   const [systemsSaved, setSystemsSaved] = useState(false);
   const [bigFileSaved, setBigFileSaved] = useState(false);
   const [advancedSaved, setAdvancedSaved] = useState(false);
-  const [scanConcurrency, setScanConcurrency] = useState(4);
+  const [scanConcurrency, setScanConcurrency] = useState(1);
   const [concSaved, setConcSaved] = useState(false);
   const [schedule, setSchedule] = useState<ScheduleStatus | null>(null);
   useEffect(() => { api.schedule().then(setSchedule).catch(() => {}); }, []);
@@ -137,7 +137,7 @@ export function Settings({ status, refresh, onAuthChange, theme, changeTheme }: 
 
   const loadSettings = () => api.settings().then((s) => {
     setTtls(s.cacheTtls); setScanTimeout(s.scanFileTimeoutSec);
-    setScanConcurrency(s.scanConcurrency ?? 4);
+    setScanConcurrency(s.scanConcurrency ?? 1);
     setEnabledConsoles(s.enabledConsoles);
     setBigFile(s.bigFileCopy ?? { enabled: false, thresholdMB: 1024, maxThresholdMB: 8192 });
     setRateLimit(s.rateLimit ?? { minIntervalMs: 0, maxRetries: 0 });
@@ -229,6 +229,37 @@ export function Settings({ status, refresh, onAuthChange, theme, changeTheme }: 
     finally { setTempBusy(false); setTimeout(() => setTempMsg(''), 4000); }
   };
   const tempKindLabel = (k: string) => t(({ upload: 'set.tempUpload', bigcopy: 'set.tempBigcopy', backup: 'set.tempBackup', extract: 'set.tempExtract' } as Record<string, string>)[k] || 'set.tempOther');
+
+  // ---- destructive resets (images / collection / hash DB) ----
+  const [resetBusy, setResetBusy] = useState('');
+  const [resetMsg, setResetMsg] = useState('');
+  const clearImages = async () => {
+    if (!window.confirm(t('set.reset.imagesConfirm'))) return;
+    setResetBusy('images'); setResetMsg('…');
+    try { const r = await api.clearImages(); setResetMsg(t('set.reset.imagesDone', { n: r.removed, size: fmtBytes(r.freed) })); await loadStorage(); }
+    catch { setResetMsg(t('common.error')); }
+    finally { setResetBusy(''); setTimeout(() => setResetMsg(''), 5000); }
+  };
+  const resetCollection = async () => {
+    if (!window.confirm(t('set.reset.collectionConfirm'))) return;
+    setResetBusy('collection'); setResetMsg('…');
+    try {
+      const r = await api.resetCollection();
+      setResetMsg(r.ok ? t('set.reset.collectionDone') : (r.error || t('common.error')));
+      await loadStorage(); refresh();
+    } catch { setResetMsg(t('common.error')); }
+    finally { setResetBusy(''); setTimeout(() => setResetMsg(''), 6000); }
+  };
+  const resetHashDb = async () => {
+    if (!window.confirm(t('set.reset.hashdbConfirm'))) return;
+    setResetBusy('hashdb'); setResetMsg('…');
+    try {
+      const r = await api.resetHashDb();
+      setResetMsg(r.ok ? t('set.reset.hashdbDone') : (r.error || t('common.error')));
+      await loadStorage(); refresh();
+    } catch { setResetMsg(t('common.error')); }
+    finally { setResetBusy(''); setTimeout(() => setResetMsg(''), 6000); }
+  };
 
   // ---- folder watch config (#1) ----
   const w = status?.watch;
@@ -746,6 +777,30 @@ export function Settings({ status, refresh, onAuthChange, theme, changeTheme }: 
           {!tempMsg && storage && !storage.temp && <span className="font-mono text-base text-ink-dim">{t('set.storageTempEmpty')}</span>}
         </div>
         {storage?.dataDir && <div className="font-mono text-sm text-ink-dim mt-2 break-all">{storage.dataDir}</div>}
+      </section>
+
+      {/* Danger zone — destructive resets (delete images / collection / hash DB) */}
+      <section className="panel p-5">
+        <h2 className="font-display text-sm flex items-center gap-2" style={{ color: 'var(--color-neon-red)' }}><AlertTriangle size={16} /> {t('set.reset.title')}</h2>
+        <p className="font-body text-ink-mid mt-2 text-sm leading-relaxed">{t('set.reset.desc')}</p>
+        <div className="mt-3 flex flex-col gap-2">
+          {[
+            { id: 'images', label: t('set.reset.images'), hint: t('set.reset.imagesHint'), on: clearImages },
+            { id: 'collection', label: t('set.reset.collection'), hint: t('set.reset.collectionHint'), on: resetCollection },
+            { id: 'hashdb', label: t('set.reset.hashdb'), hint: t('set.reset.hashdbHint'), on: resetHashDb },
+          ].map((r) => (
+            <div key={r.id} className="flex items-center gap-3 panel !rounded-lg px-3 py-2 flex-wrap">
+              <div className="min-w-0 flex-1">
+                <div className="font-body text-sm text-ink-hi">{r.label}</div>
+                <div className="font-body text-sm text-ink-dim">{r.hint}</div>
+              </div>
+              <button className="btn btn-danger !py-1.5 !px-3 text-sm shrink-0" onClick={r.on} disabled={!!resetBusy}>
+                <Trash2 size={14} className={resetBusy === r.id ? 'animate-pulse' : ''} /> {t('set.reset.action')}
+              </button>
+            </div>
+          ))}
+        </div>
+        {resetMsg && <div className="font-mono text-base mt-3 text-ink-hi">{resetMsg}</div>}
       </section>
 
       {/* Backups */}

--- a/web/src/components/UpdateChip.tsx
+++ b/web/src/components/UpdateChip.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Download, RefreshCw, RotateCw } from 'lucide-react';
+import { api } from '../lib/api';
+import { useI18n } from '../lib/i18n';
+
+type ElState = 'checking' | 'available' | 'none' | 'downloading' | 'downloaded' | 'error';
+type ElStatus = { state: ElState; version?: string; percent?: number; error?: string };
+
+declare global {
+  interface Window {
+    raUpdate?: {
+      isElectron: boolean;
+      onStatus: (cb: (s: ElStatus) => void) => () => void;
+      check: () => Promise<{ ok: boolean; error?: string }>;
+      install: () => Promise<{ ok: boolean }>;
+    };
+  }
+}
+
+// Footer chip next to the version. In the Electron desktop app it drives the
+// real auto-updater (download in background → "restart & install"). In the
+// web/.bat build it just links to the GitHub release when a newer one exists.
+export function UpdateChip() {
+  const { t } = useI18n();
+  const el = typeof window !== 'undefined' ? window.raUpdate : undefined;
+  const [status, setStatus] = useState<ElStatus | null>(null);
+  const [web, setWeb] = useState<{ newer: boolean; url?: string; latest?: string } | null>(null);
+
+  useEffect(() => {
+    if (el?.isElectron) {
+      const off = el.onStatus(setStatus);
+      el.check().catch(() => {});
+      return off;
+    }
+    api.checkUpdate()
+      .then((r) => { if (r.ok) setWeb({ newer: !!r.newer, url: r.url, latest: r.latest }); })
+      .catch(() => {});
+  }, [el]);
+
+  // ---- Electron: full auto flow ----
+  if (el?.isElectron && status) {
+    if (status.state === 'downloading') {
+      return (
+        <span className="inline-flex items-center gap-1 text-neon-amber">
+          <RefreshCw size={12} className="animate-spin" /> {t('update.downloading', { p: status.percent ?? 0 })}
+        </span>
+      );
+    }
+    if (status.state === 'downloaded') {
+      return (
+        <button onClick={() => el.install()} className="inline-flex items-center gap-1 text-neon-green hover:underline"
+          title={status.version ? `v${status.version}` : ''}>
+          <RotateCw size={12} /> {t('update.restart')}
+        </button>
+      );
+    }
+    if (status.state === 'available') {
+      return (
+        <span className="inline-flex items-center gap-1 text-neon-cyan">
+          <Download size={12} /> {t('update.available')}
+        </span>
+      );
+    }
+    return null; // checking / none / error → stay silent
+  }
+
+  // ---- Web / .bat: link to the release ----
+  if (web?.newer && web.url) {
+    return (
+      <a href={web.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-neon-cyan hover:underline"
+        title={web.latest ? `v${web.latest}` : ''}>
+        <Download size={12} /> {t('update.available')}
+      </a>
+    );
+  }
+  return null;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -245,6 +245,20 @@ export interface OfflineReadiness {
   images: number; imageBytes: number; lastFullSyncAt: number | null;
 }
 
+// ---- DAT completeness ----
+export interface DatFile {
+  id: number; name: string; description?: string | null; version?: string | null;
+  console_id: number | null; console_name?: string | null; game_count: number;
+  imported_at: number; total: number; have: number;
+}
+export interface CrcStatus { total: number; withCrc: number; without: number; }
+export interface DatMissing { game: string | null; rom: string | null; crc: string | null; size: number | null; }
+export interface DatCoverage {
+  dat: { id: number; name: string; description?: string | null; version?: string | null; console_id: number | null; game_count: number };
+  console_name?: string | null; total: number; have: number; missing: DatMissing[]; missingTotal: number; collectionCrcCount: number;
+  error?: string;
+}
+
 async function j<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
@@ -265,6 +279,19 @@ export const api = {
     }),
   storage: () => j<StorageInfo>('/api/storage'),
   clearTemp: () => j<{ ok: boolean; removed: number; freed: number; error?: string }>('/api/storage/clear-temp', { method: 'POST' }),
+  clearImages: () => j<{ ok: boolean; removed: number; freed: number }>('/api/data/clear-images', { method: 'POST' }),
+  resetCollection: () => j<{ ok: boolean; counts?: Record<string, number>; error?: string }>('/api/data/reset-collection', { method: 'POST' }),
+  resetHashDb: () => j<{ ok: boolean; counts?: Record<string, number>; error?: string }>('/api/data/reset-hashdb', { method: 'POST' }),
+  checkUpdate: () => j<{ ok: boolean; current: string; latest?: string; newer?: boolean; url?: string; notes?: string; asset?: { name: string; url: string; size: number }; error?: string }>('/api/update/check'),
+  datList: () => j<{ dats: DatFile[]; crc: CrcStatus }>('/api/dat/list'),
+  datCrcStatus: () => j<CrcStatus>('/api/dat/crc-status'),
+  datCoverage: (id: number) => j<DatCoverage>(`/api/dat/${id}/coverage`),
+  datDelete: (id: number) => j<{ ok: boolean }>(`/api/dat/${id}`, { method: 'DELETE' }),
+  datImport: (files: File[]) => {
+    const fd = new FormData();
+    for (const f of files) fd.append('files', f);
+    return j<{ ok: boolean; imported: Array<{ file: string; name: string; entries: number; games: number; console_id: number | null }>; errors: Array<{ file: string; error: string }> }>('/api/dat/import', { method: 'POST', body: fd });
+  },
   libraryForGame: (id: number) => j<OwnedFiles>(`/api/library/for-game/${id}`),
   watchConfig: (cfg: { enabled?: boolean; mode?: 'interval' | 'events'; intervalMin?: number; path?: string }) =>
     j<WatchStatus>('/api/watch/config', {

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -13,9 +13,19 @@ export const LANGS: { id: Lang; name: string; flag: string }[] = [
   { id: 'en', name: 'English', flag: '🇬🇧' },
 ];
 
+// Default to English for everyone on first run (user preference: EN is the
+// primary language). A stored choice always wins; the first-run LanguageGate
+// lets the user switch on the very first launch.
 export function loadLang(): Lang {
   const l = localStorage.getItem(KEY);
-  return l === 'en' || l === 'de' ? l : 'de';
+  return l === 'en' || l === 'de' ? l : 'en';
+}
+
+// True until the user has ever explicitly chosen a language (drives the
+// first-run language picker). Cleared implicitly once setLang persists KEY.
+export function langChosen(): boolean {
+  const l = localStorage.getItem(KEY);
+  return l === 'en' || l === 'de';
 }
 
 // Module-level mirror of the active language so non-React helpers (util.ts time
@@ -31,6 +41,20 @@ const DE: Dict = {
   'nav.scan': 'Scannen',
   'nav.games': 'Spiele',
   'nav.sync': 'Hash-DB',
+  'nav.dat': 'DAT',
+  'dat.title': 'DAT-Abgleich (Vollständigkeit)',
+  'dat.intro': 'Importiere DAT-Kataloge (No-Intro/Redump/logiqx) und sieh pro Katalog, welche Einträge du bereits hast und welche fehlen. Abgeglichen wird über die echte Datei-Prüfsumme (CRC32) deiner Sammlung — unabhängig vom RetroAchievements-Hash.',
+  'dat.import': 'DAT importieren', 'dat.importHint': 'Eine oder mehrere .dat/.xml-Dateien wählen. Unterstützt logiqx-XML und ClrMamePro.',
+  'dat.importing': 'Importiere…', 'dat.importDone': '{n} DAT(s) importiert · {games} Spiele', 'dat.importErr': 'Import fehlgeschlagen',
+  'dat.crcTitle': 'Prüfsummen der Sammlung',
+  'dat.crcNote': 'Für den Abgleich braucht jede Sammlungs-Datei ihre CRC32. ZIP-Inhalte werden direkt aus dem Archiv gelesen (schnell), lose Dateien einmalig durchgelesen. 7z/RAR-Inhalte werden in diesem Durchlauf übersprungen.',
+  'dat.crcStatus': '{have} von {total} Sammlungs-Dateien haben eine CRC.', 'dat.crcProgress': '{done} / {total} verarbeitet',
+  'dat.crcDone': 'Fertig — {computed} berechnet, {skipped} übersprungen.', 'dat.crcRun': 'CRC berechnen', 'dat.crcRunning': 'Berechne…', 'dat.crcAll': 'Alle Dateien haben eine CRC.',
+  'dat.empty': 'Noch keine DAT importiert. Oben eine .dat/.xml-Datei wählen.', 'dat.games': '{n} Spiele',
+  'dat.details': 'Details', 'dat.delete': 'Löschen', 'dat.deleteConfirm': '„{name}“ und alle Einträge löschen?',
+  'dat.cov.have': '{have} / {total} vorhanden', 'dat.cov.missing': '{n} fehlen', 'dat.cov.searchMissing': 'Fehlende durchsuchen…',
+  'dat.cov.export': 'Fehlende exportieren', 'dat.cov.noMissing': 'Nichts fehlt — vollständig!',
+  'dat.cov.crcWarn': 'Deine Sammlung hat noch keine CRC-Werte. Führe zuerst „CRC berechnen“ aus, sonst gilt alles als fehlend.',
   'nav.single': 'Einzeltest',
   'nav.profile': 'Dein Profil (Mastery · Sammlung · Insights)',
   'nav.settings': 'Einstellungen',
@@ -309,6 +333,15 @@ const DE: Dict = {
   'set.storageItems': '{n} Dateien', 'set.storageTempDesc': 'Temporär = Reste von Drag&Drop-Tests, dem Entpacken von Archiven und dem Kopieren großer Dateien. Kann gefahrlos geleert werden (nicht während eines Scans).',
   'set.storageClearTemp': 'Temp leeren', 'set.storageCleared': '{n} gelöscht · {size} frei', 'set.storageTempEmpty': 'Temp ist leer.',
   'set.tempUpload': 'Drag&Drop-Test', 'set.tempBigcopy': 'Große-Datei-Kopie', 'set.tempBackup': 'Backup-Download', 'set.tempExtract': 'Archiv-Entpacken', 'set.tempOther': 'Sonstiges',
+  'set.reset.title': 'Löschen / Zurücksetzen', 'set.reset.desc': 'Endgültig — bitte mit Bedacht. Bei Zweifel vorher ein Backup (siehe oben) anlegen.',
+  'set.reset.action': 'Löschen',
+  'set.reset.images': 'Bilder-Cache löschen', 'set.reset.imagesHint': 'Alle lokal gespeicherten Badges/Boxarts. Werden bei Bedarf automatisch neu geladen.',
+  'set.reset.imagesConfirm': 'Kompletten Bilder-Cache löschen? Bilder werden bei Bedarf neu geladen.', 'set.reset.imagesDone': '{n} Einträge gelöscht · {size} frei',
+  'set.reset.collection': 'Sammlung & Scan-Verlauf löschen', 'set.reset.collectionHint': 'Alle gescannten Dateien, Scan-Verlauf, Datei-Hash-Cache und Spielzeit-Sessions. Hash-DB und Login bleiben erhalten.',
+  'set.reset.collectionConfirm': 'Sammlung, Scan-Verlauf und Datei-Cache wirklich löschen? Hash-DB und Login bleiben erhalten.', 'set.reset.collectionDone': 'Sammlung & Verlauf gelöscht.',
+  'set.reset.hashdb': 'Hash-Datenbank löschen', 'set.reset.hashdbHint': 'Die synchronisierten RA-Spiele & -Hashes. Erzwingt einen neuen Sync. Login bleibt.',
+  'set.reset.hashdbConfirm': 'Synchronisierte Hash-Datenbank löschen? Danach ist ein neuer Sync nötig (Login bleibt).', 'set.reset.hashdbDone': 'Hash-Datenbank gelöscht — bitte neu synchronisieren.',
+  'update.available': 'Update verfügbar', 'update.downloading': 'Update lädt… {p}%', 'update.restart': 'Neustart & installieren',
   // advanced
   'set.advanced': 'ERWEITERT', 'set.advancedDesc': 'Feineinstellungen — die Standardwerte passen für die meisten.',
   'set.rateLimit': 'RA-API Tempo-Limit', 'set.rateLimitDesc': 'Mindestabstand zwischen RA-Abfragen. Höher = sanfter zu RetroAchievements, aber langsamerer Sync.',
@@ -444,7 +477,7 @@ const DE: Dict = {
   'off.sub': 'Alles Lokale in einem Archiv: Hash-DB, Spieldetails, Bilder. Für einen zweiten Rechner oder als Vollbackup.',
   'off.ready': 'Vollständig offline-fähig', 'off.notReady': 'Noch nicht komplett offline-fähig',
   'off.check.hashdb': 'Hash-Datenbank geladen', 'off.check.sync': 'Alle Systeme aktuell',
-  'off.check.details': 'Spieldetails gecacht ({v}/{need})', 'off.check.images': 'Bilder gecacht ({v})',
+  'off.check.details': 'Spieldetails gecacht: {v} (nötig ≥ {need})', 'off.check.images': 'Bilder gecacht ({v})',
   'off.check.rahasher': 'RAHasher installiert', 'off.check.profile': 'Profil gecacht',
   'off.check.completion': 'Fortschritt gecacht',
   'off.export': 'Paket exportieren', 'off.exportTip': 'DB + Bildcache als .7z herunterladen',
@@ -495,6 +528,20 @@ const EN: Dict = {
   'nav.scan': 'Scan',
   'nav.games': 'Games',
   'nav.sync': 'Hash DB',
+  'nav.dat': 'DAT',
+  'dat.title': 'DAT check (completeness)',
+  'dat.intro': 'Import DAT catalogs (No-Intro/Redump/logiqx) and see, per catalog, which entries you already have and which are missing. Matching is done by the real file checksum (CRC32) of your collection — independent of the RetroAchievements hash.',
+  'dat.import': 'Import DAT', 'dat.importHint': 'Pick one or more .dat/.xml files. Both logiqx XML and ClrMamePro are supported.',
+  'dat.importing': 'Importing…', 'dat.importDone': '{n} DAT(s) imported · {games} games', 'dat.importErr': 'Import failed',
+  'dat.crcTitle': 'Collection checksums',
+  'dat.crcNote': 'Matching needs a CRC32 for every collection file. ZIP contents are read straight from the archive (fast); loose files are read once. 7z/RAR contents are skipped in this pass.',
+  'dat.crcStatus': '{have} of {total} collection files have a CRC.', 'dat.crcProgress': '{done} / {total} processed',
+  'dat.crcDone': 'Done — {computed} computed, {skipped} skipped.', 'dat.crcRun': 'Compute CRC', 'dat.crcRunning': 'Computing…', 'dat.crcAll': 'All files have a CRC.',
+  'dat.empty': 'No DAT imported yet. Pick a .dat/.xml file above.', 'dat.games': '{n} games',
+  'dat.details': 'Details', 'dat.delete': 'Delete', 'dat.deleteConfirm': 'Delete “{name}” and all its entries?',
+  'dat.cov.have': '{have} / {total} present', 'dat.cov.missing': '{n} missing', 'dat.cov.searchMissing': 'Search missing…',
+  'dat.cov.export': 'Export missing', 'dat.cov.noMissing': 'Nothing missing — complete!',
+  'dat.cov.crcWarn': 'Your collection has no CRC values yet. Run “Compute CRC” first, otherwise everything counts as missing.',
   'nav.single': 'Single check',
   'nav.profile': 'Your profile (Mastery · Collection · Insights)',
   'nav.settings': 'Settings',
@@ -737,6 +784,15 @@ const EN: Dict = {
   'set.storageItems': '{n} files', 'set.storageTempDesc': 'Temp = leftovers from drag&drop tests, archive extraction and large-file copies. Safe to clear (not during a scan).',
   'set.storageClearTemp': 'Clear temp', 'set.storageCleared': '{n} removed · {size} freed', 'set.storageTempEmpty': 'Temp is empty.',
   'set.tempUpload': 'Drag&drop test', 'set.tempBigcopy': 'Large-file copy', 'set.tempBackup': 'Backup download', 'set.tempExtract': 'Archive extraction', 'set.tempOther': 'Other',
+  'set.reset.title': 'Delete / reset', 'set.reset.desc': 'Permanent — please be careful. When in doubt, make a backup (above) first.',
+  'set.reset.action': 'Delete',
+  'set.reset.images': 'Clear image cache', 'set.reset.imagesHint': 'All locally stored badges/box art. Re-downloaded automatically when needed.',
+  'set.reset.imagesConfirm': 'Clear the entire image cache? Images are re-downloaded when needed.', 'set.reset.imagesDone': '{n} entries removed · {size} freed',
+  'set.reset.collection': 'Delete collection & scan history', 'set.reset.collectionHint': 'All scanned files, scan history, file-hash cache and playtime sessions. Hash DB and login are kept.',
+  'set.reset.collectionConfirm': 'Really delete the collection, scan history and file cache? The hash DB and login are kept.', 'set.reset.collectionDone': 'Collection & history deleted.',
+  'set.reset.hashdb': 'Delete hash database', 'set.reset.hashdbHint': 'The synced RA games & hashes. Forces a fresh sync. Login is kept.',
+  'set.reset.hashdbConfirm': 'Delete the synced hash database? A fresh sync will be required afterwards (login is kept).', 'set.reset.hashdbDone': 'Hash database deleted — please re-sync.',
+  'update.available': 'Update available', 'update.downloading': 'Downloading update… {p}%', 'update.restart': 'Restart & install',
   'set.advanced': 'ADVANCED', 'set.advancedDesc': 'Fine-tuning — the defaults work for most.',
   'set.rateLimit': 'RA API rate limit', 'set.rateLimitDesc': 'Minimum spacing between RA requests. Higher = gentler on RetroAchievements, slower sync.',
   'set.rateInterval': 'Min interval (ms)', 'set.rateRetries': 'Retries',
@@ -869,7 +925,7 @@ const EN: Dict = {
   'off.sub': 'Everything local in one archive: hash DB, game details, images. For a second machine or as a full backup.',
   'off.ready': 'Fully offline-capable', 'off.notReady': 'Not fully offline-capable yet',
   'off.check.hashdb': 'Hash database loaded', 'off.check.sync': 'All systems up to date',
-  'off.check.details': 'Game details cached ({v}/{need})', 'off.check.images': 'Images cached ({v})',
+  'off.check.details': 'Game details cached: {v} (need ≥ {need})', 'off.check.images': 'Images cached ({v})',
   'off.check.rahasher': 'RAHasher installed', 'off.check.profile': 'Profile cached',
   'off.check.completion': 'Progress cached',
   'off.export': 'Export package', 'off.exportTip': 'Download DB + image cache as .7z',

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version + changelog. The footer version
 // chip opens a modal rendering CHANGELOG; package.json is kept in sync manually.
-export const APP_VERSION = '0.9.5';
+export const APP_VERSION = '0.10.0';
 
 // GitHub repository — linked from the header (GitHub icon in the "More" menu).
 export const REPO_URL = 'https://github.com/x3kim/RAChecker';
@@ -12,6 +12,19 @@ export interface Release { version: string; date: string; title?: { de: string; 
 
 // Newest first. Dates are ISO (YYYY-MM-DD).
 export const CHANGELOG: Release[] = [
+  {
+    version: '0.10.0',
+    date: '2026-07-25',
+    title: { de: 'DAT-Abgleich, Auto-Update & Sprachwahl', en: 'DAT check, auto-update & language picker' },
+    changes: [
+      { type: 'feature', de: 'Neuer Bereich „DAT": Importiere No-Intro/Redump/logiqx-Kataloge und sieh pro Katalog, welche Einträge du bereits hast und welche fehlen — abgeglichen über die echte Datei-Prüfsumme (CRC32) deiner Sammlung, unabhängig vom RetroAchievements-Hash. Die Liste der fehlenden Spiele lässt sich exportieren.', en: 'New "DAT" area: import No-Intro/Redump/logiqx catalogs and see, per catalog, which entries you already have and which are missing — matched by your collection\'s real file checksum (CRC32), independent of the RetroAchievements hash. The list of missing games can be exported.' },
+      { type: 'feature', de: 'Automatische Updates (Desktop-App): RAChecker prüft beim Start auf eine neue Version, lädt sie im Hintergrund und bietet unten links „Neustart & installieren". Die Web-/Startskript-Version zeigt stattdessen einen Link zur neuen Version.', en: 'Automatic updates (desktop app): RAChecker checks for a new version on launch, downloads it in the background and offers "Restart & install" bottom-left. The web/launcher build instead shows a link to the new release.' },
+      { type: 'feature', de: 'Sprachauswahl beim allerersten Start (mit Flaggen). Englisch ist jetzt die Standardsprache.', en: 'Language picker on the very first launch (with flags). English is now the default language.' },
+      { type: 'feature', de: 'Einstellungen → Daten & Speicher: Bilder-Cache, Sammlung & Scan-Verlauf oder die Hash-Datenbank gezielt löschen (vorher nur „Temp leeren").', en: 'Settings → Data & storage: delete the image cache, the collection & scan history, or the hash database individually (previously only "clear temp").' },
+      { type: 'improve', de: 'Parallele Scan-Dateien standardmäßig auf 1 (ruhiger, klarerer Fortschritt). Hinweis: ein Archiv mit mehreren ROMs zeigt nacheinander mehrere Dateinamen — das ist kein paralleles Scannen, sondern die einzelnen Einträge im Archiv.', en: 'Parallel scan files now default to 1 (calmer, clearer progress). Note: an archive containing several ROMs shows multiple filenames in sequence — that is not parallel scanning but the individual entries inside the archive.' },
+      { type: 'fix', de: 'Offline-Check „Spieldetails gecacht" ist jetzt klar formuliert („33 (nötig ≥ 24)" statt des verwirrenden „33/24"). Der Wert zählt alle gecachten Details, die Zahl dahinter ist das Minimum für deine eigenen spielbaren Spiele.', en: 'Offline check "game details cached" is now worded clearly ("33 (need ≥ 24)" instead of the confusing "33/24"). The value counts all cached details; the number after it is the minimum for your own playable games.' },
+    ],
+  },
   {
     version: '0.9.5',
     date: '2026-07-25',


### PR DESCRIPTION
Second feedback batch (Reddit + user wishlist). Version bump 0.9.5 → 0.10.0.

## What changed

**DAT completeness check (new "DAT" nav tab)**
- Import No-Intro/Redump/logiqx (XML) + ClrMamePro (text) catalogs.
- Match the collection by **raw file CRC32** — a separate dimension from the RA hash (which strips iNES headers, byte-swaps N64, hashes arcade filenames …). New `library.crc` column.
- CRC pass over the collection: ZIP members read their CRC straight from the central directory (no decompression); loose files stream; 7z/RAR members skipped in this pass. SSE progress.
- Per-catalog have/miss with an exportable missing list.
- Server: `server/src/dat.js` (parser + CRC32), `dat_files`/`dat_entries` tables, routes `/api/dat/import|list|:id/coverage|crc-status`, `DELETE /api/dat/:id`, SSE `/api/dat/scan-crc/stream`.

**Electron auto-update (electron-updater, GitHub feed)**
- Background download + "restart & install" chip in the footer.
- Web/.bat build falls back to a `/api/update/check` GitHub link.
- `electron/preload.cjs` bridge (`window.raUpdate`), `publish: github` in `electron-builder.yml`, and a space-free `nsis.artifactName` so `latest.yml` ↔ the uploaded asset name match (otherwise the updater 404s).

**First-run language picker + English default**
- `loadLang()` default `de` → `en`; `index.html` `lang="en"`.
- `LanguageGate.tsx` shown once when no language was ever chosen.
- Real inline **SVG flags** (`Flag.tsx`) — emoji regional-indicator flags do not render as flags on Windows.

**Settings → Data & storage**
- Delete image cache / collection & scan history / hash database individually (previously only "clear temp"). New `resetCollection`/`resetHashDb` + `/api/data/clear-images|reset-collection|reset-hashdb`.

**Smaller fixes from the feedback list**
- Parallel scan files default `4 → 1`.
- Offline check "game details cached" reads `33 (need ≥ 24)` instead of the confusing `33/24` (value = all cached detail blobs, need = your own playable games — not a bug, just unclear wording).

## Reviewer notes
- **Auto-update caveat:** only works from 0.10.0 installs onward, for future releases, and only if the GitHub release contains `latest.yml` + the installer exe + its `.blockmap` (all three are produced in `release/`; upload all three, or build with `electron-builder --publish`). Already-installed 0.9.5 cannot retroactively self-update.
- Android was explicitly deferred to its own session (a real APK needs a rewrite — the Node server / RAHasher / NAS scan don't run on Android).

## Verification
- `npm run build` (tsc + vite) clean.
- `npm test` → 33/33 pass.
- Isolated DAT/CRC suite → 13/13 (incl. CRC32 canonical `123456789` → `cbf43926`, logiqx + ClrMamePro parse, coverage matching).
- Endpoints probed live; UI checked in-browser (EN default, language gate + DE switch, DAT view, reset section, cached line, concurrency = 1).
- exe built: `RAChecker-Setup-0.10.0.exe` + portable + `latest.yml` (gitignored, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a DAT completeness tab for catalog-based CRC32 matching, add Electron auto-update integration, and improve language selection and data reset controls alongside minor UX tweaks and a version bump to v0.10.0.

New Features:
- Add DAT completeness support with importable catalog files and per-DAT coverage views based on collection CRC32.
- Enable automatic update checks and in-app restart & install flow for the Electron desktop build, with a GitHub-based fallback for the web/launcher build.
- Show a first-run language picker with SVG flags and make English the default UI language.
- Expose targeted data reset actions for image cache, collection and scan history, and the hash database in Settings.

Enhancements:
- Default scan concurrency to a single worker to make progress clearer and scans calmer.
- Clarify offline readiness messaging for cached game details by separating the total cached count from the required minimum.

Build:
- Configure electron-builder to publish GitHub release artifacts compatible with electron-updater, including a consistent NSIS installer name.
- Bump app and web package versions from 0.9.5 to 0.10.0.