### PR TITLE
feat(mobile): hash Nintendo DS ROMs, and let the scanner see them at all

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "RAChecker",
     "slug": "rachecker",
     "owner": "x3dev",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
@@ -13,7 +13,7 @@
     },
     "android": {
       "package": "de.rachecker.app",
-      "versionCode": 10,
+      "versionCode": 11,
       "adaptiveIcon": {
         "backgroundColor": "#0a0e14",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1108,12 +1108,12 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-57.0.6.tgz",
-      "integrity": "sha512-VpMJpB/De/fb9bBFVVBiK6Ntg9lt0kAleLH9hcZz85CYRUQ3jVFVA8rNC5f8y4cp2+FiiPNFp62+kEOFI6pDiw==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-57.0.8.tgz",
+      "integrity": "sha512-7VpAu2ZMXNZI0+Kn+nD3vQBIyST89LATNkZpnp/cXh8/aj7zUXO8d/T+hOxsvhOFwR8eQO+jKXEw8tQbidiMxA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/config-types": "^57.0.2",
         "@expo/json-file": "^11.0.1",
         "@expo/require-utils": "^57.0.4",
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.8.tgz",
+      "integrity": "sha512-x6lx4s/19i39/+1dMPwb9tFCc4WR843dG5Yi+C64lhKL3YHX+6oKrT2Kv72PCEalnUY+usQDkB3NrLSrYOWtDg==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^57.0.2",
@@ -1192,6 +1192,17 @@
         }
       }
     },
+    "node_modules/@expo/dom-webview": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-57.0.1.tgz",
+      "integrity": "sha512-lAKsME4SAq+8sf56oN0DX5TBYyruupoRxbWbD2xf9RnKY8y6x8eb9LCE5pxSN0qyWdqnp+0wmyWzDkKboThKAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/env": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.4.2.tgz",
@@ -1213,9 +1224,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.6.tgz",
-      "integrity": "sha512-cmC/6BOPRbdKr77Mgjwszb8aM0hY2RKBpMRCmjSdn9zIcn2FGor/ic4fHVr46cQFa1G6RDGg1GyAjRw3US4CCQ==",
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.8.tgz",
+      "integrity": "sha512-0UOg9dVepR0LO4iUacoFuWZ9GNSUdUkdx9GX+Rj0mRpOTAtavyiem8IfewCAHij3cppqjBic134JD2lUxsZcJw==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "^2.4.2",
@@ -1250,12 +1261,12 @@
       }
     },
     "node_modules/@expo/inline-modules": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.1.3.tgz",
-      "integrity": "sha512-eHSxWYfgq65mP3Qz8PclVjUkSrDIlGl3va9U7PMcTpGItOvee/i0ZzGinH5A25oARR5ouD64eESBKwtT/CwdHg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.1.6.tgz",
+      "integrity": "sha512-5f6EiOIKsFj9zlrCBet4ZIQRPEa9dBUdQgTzpjYwdZ8Z/M8W5lqMVL9dEs4HYKvEmDnqv0dQuDkFLyRSwu/DAQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~57.0.5"
+        "@expo/config-plugins": "~57.0.8"
       }
     },
     "node_modules/@expo/json-file": {
@@ -1269,13 +1280,30 @@
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.4.tgz",
-      "integrity": "sha512-B/cI73shkLSYBYuFyh+zCbS+WhqJgawWPW4MPdMiNLJKv9RmV4dv1FGjsidiIiG2k4kYKerBDLK4bLbC7qERQQ==",
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.6.tgz",
+      "integrity": "sha512-6aFMROb1SzIvrefpwhgS5QGNELU9T2lpK0Hcl6oiZ4/mbKgZRk0WEPauo/dHH6IgDmyK25InCMHF5nj7XY4LWg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~57.0.5",
+        "@expo/config": "~57.0.7",
         "chalk": "^4.1.2"
+      }
+    },
+    "node_modules/@expo/log-box": {
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.3.tgz",
+      "integrity": "sha512-qv/cMliNax6es07Un/4IGJIcs4PUuhTKKTrJZX/0X2YRcOT5cqm/QicibZwTIbiZWi1i8P4YBRQTfFT2B17giw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/dom-webview": "^57.0.1",
+        "anser": "^1.4.9",
+        "stacktrace-parser": "^0.1.10"
+      },
+      "peerDependencies": {
+        "@expo/dom-webview": "^57.0.1",
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@expo/metro": {
@@ -1298,6 +1326,72 @@
         "metro-symbolicate": "0.84.4",
         "metro-transform-plugins": "0.84.4",
         "metro-transform-worker": "0.84.4"
+      }
+    },
+    "node_modules/@expo/metro-config": {
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.8.tgz",
+      "integrity": "sha512-cZOVjbljqRBMCXcloc5k23gsFOhWdiKXhDkp5jU/wY6IXR6G7cYtNOwxKfxI1QLhs0KcXY0gDmZ2UIueoHzY7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~57.0.7",
+        "@expo/env": "~2.4.2",
+        "@expo/json-file": "~11.0.1",
+        "@expo/metro": "~56.0.0",
+        "@expo/require-utils": "^57.0.4",
+        "@expo/spawn-async": "^1.8.0",
+        "@jridgewell/gen-mapping": "^0.3.13",
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "hermes-parser": "^0.36.0",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-estree": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.1.tgz",
+      "integrity": "sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-parser": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.1.tgz",
+      "integrity": "sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.36.1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/metro-file-map": {
@@ -1352,22 +1446,28 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.9.tgz",
-      "integrity": "sha512-8g7RoXFvO/dxvLzRE/bvphzDL4bfV0w3/4Aj6DfwvgymZ1ULz5gW2x0js94opZRoZvWw4SolH6/74hLlZT3rAA==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.12.tgz",
+      "integrity": "sha512-3vwrQ2DSGijJUa8K/j3xUfOdhYgygKdWAjJ7o3r143BGnKD1SwPIMEN7dSDhkmDWR4FAXTQwgaD8dHh5VZd/jA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config": "~57.0.7",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/config-types": "^57.0.2",
         "@expo/image-utils": "^0.11.4",
         "@expo/json-file": "^11.0.1",
-        "@react-native/normalize-colors": "0.86.0",
+        "@react-native/normalize-colors": "0.86.2",
         "debug": "^4.3.1",
-        "expo-modules-autolinking": "~57.0.9",
+        "expo-modules-autolinking": "~57.0.10",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@react-native/normalize-colors": {
+      "version": "0.86.2",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.2.tgz",
+      "integrity": "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg==",
+      "license": "MIT"
     },
     "node_modules/@expo/require-utils": {
       "version": "57.0.4",
@@ -1559,16 +1659,52 @@
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.86.0.tgz",
-      "integrity": "sha512-qdsABWNW7uTll90l4Vh03gjeyu3WVDi2CyiiyvYGMRDcoYbjbQi6df3BMAm9lQI2yslZ1T14LlDDAsgTwNxplA==",
+      "version": "0.86.2",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.86.2.tgz",
+      "integrity": "sha512-NNDZqOlNbH5SzgPks1jFDYH3234Rpa5e/nhZymxhIiBH3NcE3uD+rGj/HWXhH7nHF2ToGK6XbUpqy7nmJPeh+g==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.0",
-        "@react-native/codegen": "0.86.0"
+        "@react-native/codegen": "0.86.2"
       },
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/@react-native/codegen": {
+      "version": "0.86.2",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.2.tgz",
+      "integrity": "sha512-xKkudsahUJ1n//55g4fXk5BStVqqmZlz8HQveL45ZxcfDnwvhuYe2GymksQANFsSN+slvrarjrfq8kIxJzbceA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.36.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-estree": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
+      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.36.0"
       }
     },
     "node_modules/@react-native/codegen": {
@@ -1801,9 +1937,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
+      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1856,9 +1992,9 @@
       }
     },
     "node_modules/agent-cli-detector": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.4.tgz",
-      "integrity": "sha512-qPgevFvpaQoBaRJVKzr8R7h1WPvV3DtbgRIQlne4le66KBzXx5hNBwo/+NTw67LgkKBlhCzksrdautpUdlls0Q==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.6.tgz",
+      "integrity": "sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA==",
       "license": "MIT",
       "bin": {
         "agent-cli-detector": "dist/cli.js"
@@ -2044,6 +2180,73 @@
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
     },
+    "node_modules/babel-preset-expo": {
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.7.tgz",
+      "integrity": "sha512-/1RLnZTJVoTNo6nCdSv27BSA2LBzM/qEkNLznwWvztg64DhsAz7ByZIiAqdbau9FK3YqF+IV5a2ZsPXFclwq4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/generator": "^7.20.5",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/plugin-proposal-decorators": "^7.12.9",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.28.6",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@babel/plugin-transform-react-pure-annotations": "^7.27.1",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-plugin-codegen": "0.86.2",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "babel-plugin-react-native-web": "~0.21.0",
+        "babel-plugin-syntax-hermes-parser": "^0.36.0",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.0",
+        "expo": "*",
+        "expo-widgets": "^57.0.10",
+        "react-refresh": ">=0.14.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/runtime": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        },
+        "expo-widgets": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2116,9 +2319,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2446,12 +2649,15 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
+      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1"
+        "browserslist": "^4.28.7"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2642,31 +2848,31 @@
       }
     },
     "node_modules/expo": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.8.tgz",
-      "integrity": "sha512-0IxxoPZbT54IH4fHL5NihkvED9HBVQx3uNdPvyv8pFUHWJ81RdFjL0aJys1IB7hbo09KTz4xW4I2aWVOXKAcJQ==",
+      "version": "57.0.14",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.14.tgz",
+      "integrity": "sha512-vJ7V/VNr2IGxhhBdRs1qDExPbEe+DvfqVGp3818gyfr4k0l7mdBb1QuDFH0VCX6wT9/18EYxW7SQca4tXkzDYw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^57.0.10",
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/cli": "^57.0.16",
+        "@expo/config": "~57.0.8",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/devtools": "~57.0.1",
         "@expo/dom-webview": "~57.0.1",
-        "@expo/fingerprint": "^0.20.6",
-        "@expo/local-build-cache-provider": "^57.0.4",
-        "@expo/log-box": "^57.0.1",
+        "@expo/fingerprint": "^0.20.8",
+        "@expo/local-build-cache-provider": "^57.0.6",
+        "@expo/log-box": "^57.0.3",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.7",
+        "@expo/metro-config": "~57.0.8",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~57.0.4",
-        "expo-asset": "~57.0.7",
-        "expo-constants": "~57.0.7",
-        "expo-file-system": "~57.0.1",
+        "babel-preset-expo": "~57.0.7",
+        "expo-asset": "~57.0.12",
+        "expo-constants": "~57.0.12",
+        "expo-file-system": "~57.0.4",
         "expo-font": "~57.0.1",
         "expo-keep-awake": "~57.0.1",
-        "expo-modules-autolinking": "~57.0.9",
-        "expo-modules-core": "~57.0.7",
+        "expo-modules-autolinking": "~57.0.10",
+        "expo-modules-core": "~57.0.11",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -2703,6 +2909,34 @@
         }
       }
     },
+    "node_modules/expo-asset": {
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.12.tgz",
+      "integrity": "sha512-DbNxGsmqCaE2LWyabXEkDqV/8/mrZ2ikmVzi1V1Dp4MaQO9Kde6VcvQk7h6NVsklmo4xPT1J2Lnrs8Vd18sXOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.11.4",
+        "expo-constants": "~57.0.12"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.12.tgz",
+      "integrity": "sha512-js9qxZw4G9ulSc72GGpYGwtmk/IzFcf6/tTcEG6wB8HTlkunMS4W86R+4e6oHIrIkHA7W6s/79Se+E+DC3RAqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/env": "~2.4.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-document-picker": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-57.0.1.tgz",
@@ -2713,9 +2947,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.1.tgz",
-      "integrity": "sha512-w7/ERvQFrGP2apTO9lDtZ+O6JQIhfakL7+Xqzh+rfMO9B4LB4qwrz+YvLgir8KFRVX64JHBnRuYBVLY1oQZcqw==",
+      "version": "57.0.4",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.4.tgz",
+      "integrity": "sha512-h8qDOxSW1SQfnZyvH0+HeOfXCr2X4v3x50+d19JuyQcjDR+JA3tng20TlQxIHazzLPPbwtSKA1Dj3+XIOpnoKg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -2757,9 +2991,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-57.0.9.tgz",
-      "integrity": "sha512-lj2nsAKMMRLXSFnGgaaQrWJ2fdSpLPc/bca6Rkiw4g8zYPn7qX4MRUJgavvzm/hBrzvMnlhXVgJtidOGuwBh+w==",
+      "version": "57.0.10",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-57.0.10.tgz",
+      "integrity": "sha512-jNqLswMx8QHN8VXRgud+xT+9q+J9U63CEGlx+k4V/IE9Qyt9HrKbWp+pIDma0fOquta5HBfSfsShcI+NkEpTiA==",
       "license": "MIT",
       "dependencies": {
         "@expo/require-utils": "^57.0.4",
@@ -2772,9 +3006,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.7.tgz",
-      "integrity": "sha512-5HrbCfgYmLs0a5dzfM4GmRGelVTPIg+eYp0vmSbWnKRTOPj5DyVOfg1rHGEsuNKp07QwDxfLJfQVp8CNbuvxMQ==",
+      "version": "57.0.11",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.11.tgz",
+      "integrity": "sha512-gzRAI+vs0g9eObyQfGq1kp017flMeqZMzprqquCWxKg/AYdJXKmGXibJqMVFvRbUpluYBsW8U9P0inntKbzJOg==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.6.1",
@@ -2811,21 +3045,21 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-57.0.1.tgz",
-      "integrity": "sha512-sBfVDH6dmKVHZxqUxbfkzS00PZELMZt1IpnHKxcOTMZtR/t7CtRAFrbXcisG+EyzeqHSVDacZT+1tbYfZt5D8w==",
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-57.0.3.tgz",
+      "integrity": "sha512-aK+LdKzauHSGmsOStZtyxdzv0zWssCkxTw3m4QuOhfDSJsZaMRTd9O41d8ixU/QfELTbaJ0oRNcF7JFV/7O9YQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
       }
     },
     "node_modules/expo-sharing": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-57.0.7.tgz",
-      "integrity": "sha512-mGP4yEvBJzNScGSBLOqAZMuGbxqTF9R8Fr1vh/50M4mvkObXAXMQvVZm1WnjD/2RFQrqo87z+K1TtcqEcHzs7g==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-57.0.13.tgz",
+      "integrity": "sha512-8kRUBikuR+c90++PF4PaP8pj+McUNi7AIZkwmn0iXcA8QobkJDSAjSB3fP8qoFm8bzHDhyibHIlODTAsxrMYMw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "^57.0.6",
+        "@expo/config-plugins": "^57.0.8",
         "@expo/config-types": "^57.0.2",
         "@expo/plist": "^0.8.1"
       },
@@ -2881,34 +3115,34 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "57.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.10.tgz",
-      "integrity": "sha512-mP+B9ZrTnRE94bxPM/kCVKPyuVuOTRvvsqbXVxdXtrAfOfF94YIZLGUtw/151cGFtdUPbsBsJ9gW02LhU+QMZA==",
+      "version": "57.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.16.tgz",
+      "integrity": "sha512-+HyMY2nAS6QBJb0nSeMz92p11bZ1AtWSRnhWnklznN07IRoQirisnKq2vr18Ayjb/fnb5F/um+n6FRhF0fZm1Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config": "~57.0.8",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.4.2",
         "@expo/image-utils": "^0.11.4",
-        "@expo/inline-modules": "^0.1.3",
+        "@expo/inline-modules": "^0.1.6",
         "@expo/json-file": "^11.0.1",
-        "@expo/log-box": "^57.0.1",
+        "@expo/log-box": "^57.0.3",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.7",
+        "@expo/metro-config": "~57.0.8",
         "@expo/metro-file-map": "^57.0.1",
         "@expo/osascript": "^2.7.1",
         "@expo/package-manager": "^1.13.1",
         "@expo/plist": "^0.8.1",
-        "@expo/prebuild-config": "^57.0.9",
+        "@expo/prebuild-config": "^57.0.12",
         "@expo/require-utils": "^57.0.4",
-        "@expo/router-server": "^57.0.4",
+        "@expo/router-server": "^57.0.6",
         "@expo/schema-utils": "^57.0.2",
         "@expo/spawn-async": "^1.8.0",
         "@expo/ws-tunnel": "^2.0.0",
         "@expo/xcpretty": "^4.4.4",
-        "@react-native/dev-middleware": "0.86.0",
+        "@react-native/dev-middleware": "0.86.2",
         "accepts": "^1.3.8",
         "agent-cli-detector": "^0.1.2",
         "arg": "^5.0.2",
@@ -2920,12 +3154,12 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "dnssd-advertise": "^1.1.4",
-        "expo-server": "^57.0.1",
+        "expo-server": "^57.0.3",
         "fetch-nodeshim": "^0.4.10",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "lan-network": "^0.2.1",
-        "multitars": "^1.0.0",
+        "multitars": "^1.0.2",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
@@ -2934,6 +3168,7 @@
         "progress": "^2.0.3",
         "prompts": "^2.3.2",
         "resolve-from": "^5.0.0",
+        "sandbox-cli-detector": "^0.2.0",
         "semver": "^7.6.0",
         "send": "^0.19.0",
         "slugify": "^1.3.4",
@@ -2963,20 +3198,20 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/router-server": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.4.tgz",
-      "integrity": "sha512-ucqCP0hK8nZb9+S8QJYdQxNCkfRClzkKdg2RpWYDKDYgRIHyoRyxEDRgDgvbhH+q78yfY83abU8OTx8MMOrf1g==",
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.6.tgz",
+      "integrity": "sha512-/0H7OIilU4lmdR3V9UZuKou71cwaJ11sneW8/T6Rtr46LA71lgBWzdRldvVxaWv8dT+cu90f4jl+M3DYXN9MqQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^57.0.7",
+        "@expo/metro-runtime": "^57.0.10",
         "expo": "*",
-        "expo-constants": "^57.0.7",
+        "expo-constants": "^57.0.11",
         "expo-font": "^57.0.1",
         "expo-router": "*",
-        "expo-server": "^57.0.1",
+        "expo-server": "^57.0.3",
         "react": "*",
         "react-dom": "*",
         "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
@@ -2996,73 +3231,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/dom-webview": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-57.0.1.tgz",
-      "integrity": "sha512-lAKsME4SAq+8sf56oN0DX5TBYyruupoRxbWbD2xf9RnKY8y6x8eb9LCE5pxSN0qyWdqnp+0wmyWzDkKboThKAw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/log-box": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.1.tgz",
-      "integrity": "sha512-fuVNHhOerdRWtpq27gD6JTSVYESsfRu+SMdrNCWxW+gFnusS6dGKfx3lKGBZ4ZkMNiLWn8maBHo39YKzJNXFYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/dom-webview": "^57.0.1",
-        "anser": "^1.4.9",
-        "stacktrace-parser": "^0.1.10"
-      },
-      "peerDependencies": {
-        "@expo/dom-webview": "^57.0.1",
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/metro-config": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.7.tgz",
-      "integrity": "sha512-bVfEkg4zF1cA62OqAdYXmFOooJ6TB/I+REi7Se6Ct+PbSC+89TwSqWXnYx34L08eIs4z+1ilgbATakTZpgefmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@expo/config": "~57.0.6",
-        "@expo/env": "~2.4.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/metro": "~56.0.0",
-        "@expo/require-utils": "^57.0.4",
-        "@expo/spawn-async": "^1.8.0",
-        "@jridgewell/gen-mapping": "^0.3.13",
-        "@jridgewell/remapping": "^2.3.5",
-        "@jridgewell/sourcemap-codec": "^1.5.5",
-        "browserslist": "^4.25.0",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "hermes-parser": "^0.36.0",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "^1.30.1",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/expo/node_modules/@expo/ws-tunnel": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-2.0.0.tgz",
@@ -3070,6 +3238,73 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "^8.0.0"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/debugger-frontend": {
+      "version": "0.86.2",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.2.tgz",
+      "integrity": "sha512-KGS1aV5F6cIqpnoIUhLBXyVzy1oAj8jBFGau6vX4Vy0HXRJN7p+68RU7x6NuyraHvQcR14ccMGT5TkFuNjQ4gA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/debugger-shell": {
+      "version": "0.86.2",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.2.tgz",
+      "integrity": "sha512-/TaVJ2+gGajZPJGrFaObUQmHmlaxAlfmOPZicl6pNKDUjzSgFMpcLkdTOExvb+USYTVdGX1XwxXyvjQdUO2bvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.4.0",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/dev-middleware": {
+      "version": "0.86.2",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.2.tgz",
+      "integrity": "sha512-B7L0vKvg+IcEElT7Vpqh1xj5yJAqWUegjbP+bQRaorJMAYnv11GkliTnZV2AdTDfZQJWgOEx8i8LGkHkUg7bnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.86.2",
+        "@react-native/debugger-shell": "0.86.2",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.3.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo/node_modules/accepts": {
@@ -3083,73 +3318,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/expo/node_modules/babel-preset-expo": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.4.tgz",
-      "integrity": "sha512-EkFcNoE23HVzQT6ZNXs/adN8+G7rqEAF6tQn6LpRPYa1YY7wmX5GxhJF0kaYMNtBndNrMTN4+0rYE17VG13KFg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "^7.20.5",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.28.6",
-        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
-        "@babel/plugin-transform-react-pure-annotations": "^7.27.1",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-plugin-codegen": "0.86.0",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.36.0",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.20.0",
-        "expo": "*",
-        "expo-widgets": "^57.0.6",
-        "react-refresh": ">=0.14.0 <1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/runtime": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        },
-        "expo-widgets": {
-          "optional": true
-        }
       }
     },
     "node_modules/expo/node_modules/ci-info": {
@@ -3167,34 +3335,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/expo/node_modules/expo-asset": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.7.tgz",
-      "integrity": "sha512-TA6MRQq1HL0N6KGvNMzL6djdH5tGJ/eHPIhML+6bVu52mnXldmup2swdvP37zDnvoMUUXRVGsvwVHFmvhCbW6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/image-utils": "^0.11.4",
-        "expo-constants": "~57.0.7"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.7.tgz",
-      "integrity": "sha512-ShDwaKnh3UieCQ/dG0kO8PuicTTatn3WDGmXbq/fukyzPXWhdUxf37DINVDQS6D3DDG7nfqItij+QvnDHSQhTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/env": "~2.4.2"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/expo-keep-awake": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.1.tgz",
@@ -3203,21 +3343,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
-      }
-    },
-    "node_modules/expo/node_modules/hermes-estree": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.1.tgz",
-      "integrity": "sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw==",
-      "license": "MIT"
-    },
-    "node_modules/expo/node_modules/hermes-parser": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.1.tgz",
-      "integrity": "sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.36.1"
       }
     },
     "node_modules/expo/node_modules/mime-db": {
@@ -3263,9 +3388,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3773,9 +3898,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -4608,12 +4733,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4650,15 +4775,15 @@
       "license": "MIT"
     },
     "node_modules/multitars": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.0.tgz",
-      "integrity": "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.2.tgz",
+      "integrity": "sha512-6GwVw5eLi9sThdtlS4PKwC7yRLaf45pYhIEzKBHdKxi+YOXGKFX8acIniH+Uh/+k9mS2lQOupTccjoe5r0/1IQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -4991,9 +5116,9 @@
       }
     },
     "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
+      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -5009,9 +5134,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5028,7 +5153,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5368,6 +5493,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/sandbox-cli-detector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sandbox-cli-detector/-/sandbox-cli-detector-0.2.0.tgz",
+      "integrity": "sha512-4lyHX0ZU0AZKwjgZ1InxZAa3PNpyEb8rOQ+Zss1ReYmhNzW0Q+h1zE5nvniXN0HaAWZaZE1zgVNEirb0R7LmNg==",
+      "license": "MIT",
+      "bin": {
+        "sandbox-cli-detector": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
     },
     "node_modules/sax": {
       "version": "1.6.1",

--- a/mobile/src/core/consoles.js
+++ b/mobile/src/core/consoles.js
@@ -18,6 +18,9 @@ const EXT = {
   '.lnx': { consoleId: 13, headerRule: 'lynx' },
   '.pce': { consoleId: 8,  headerRule: 'pce' },
   '.a78': { consoleId: 51, headerRule: 'a7800' },
+  '.nds': { consoleId: 18, headerRule: null },
+  '.dsi': { consoleId: 78, headerRule: null },
+  '.ids': { consoleId: 18, headerRule: null },
 };
 
 export function consoleForExt(ext) {

--- a/mobile/src/core/index.js
+++ b/mobile/src/core/index.js
@@ -1,3 +1,4 @@
 export * from './rules.js';
 export * from './consoles.js';
+export * from './nds.js';
 export * from './region.js';

--- a/mobile/src/core/nds.js
+++ b/mobile/src/core/nds.js
@@ -1,0 +1,85 @@
+// The RetroAchievements Nintendo DS / DSi hash.
+// Source of truth: rcheevos src/rhash/hash_rom.c, rc_hash_nintendo_ds().
+//
+// Unlike the cartridge rules in rules.js this is not one pass over the file. A
+// DS ROM is a container: its 512-byte header points at an ARM9 code block, an
+// ARM7 code block and an icon/title block, and only those four pieces are
+// hashed — in that order, with everything between them ignored. That is why a
+// plain whole-file MD5 of a .nds never matches RetroAchievements.
+//
+// The byte source is therefore a random-access reader, not a buffer, and MD5 is
+// injected as an incremental accumulator so the identical code runs under Node
+// (crypto) and React Native (js-md5).
+
+// Extensions that carry a DS ROM. `.srl` is shared with Game Boy Advance and
+// `.ids` with DSi, so callers should treat the DS hash as one candidate among
+// others rather than the only answer for those two.
+export const NDS_EXTS = new Set(['.nds', '.dsi', '.ids', '.srl']);
+
+const HEADER_BYTES = 512;   // read; only the first 0x160 are hashed
+const HASHED_HEADER = 0x160;
+const ICON_BYTES = 0xa00;
+// ARM9 + ARM7 are typically well under 1 MB each. rcheevos treats anything past
+// 16 MB as proof this is not a DS ROM rather than trying to read it.
+const MAX_CODE_BYTES = 16 * 1024 * 1024;
+
+// A SuperCard flash cart prepends its own 512-byte header; the real DS header
+// follows it and every address in it is relative to that shifted origin.
+function hasSuperCardHeader(h) {
+  return h[0] === 0x2e && h[1] === 0x00 && h[2] === 0x00 && h[3] === 0xea
+    && h[0xb0] === 0x44 && h[0xb1] === 0x46 && h[0xb2] === 0x96 && h[0xb3] === 0x00;
+}
+
+function u32le(b, at) {
+  return (b[at] | (b[at + 1] << 8) | (b[at + 2] << 16) | (b[at + 3] << 24)) >>> 0;
+}
+
+// Read exactly `length` bytes at `offset`, zero-filling whatever the file does
+// not provide. rcheevos 0-pads a short icon block explicitly; for the code
+// blocks it would hash uninitialised memory, which no real dump reaches and
+// which cannot be reproduced — zeroes keep a truncated file deterministic.
+async function readPadded(reader, offset, length) {
+  const out = new Uint8Array(length);
+  if (offset >= reader.size) return out;
+  const got = await reader.read(offset, Math.min(length, reader.size - offset));
+  out.set(got.subarray(0, Math.min(got.length, length)));
+  return out;
+}
+
+/**
+ * Hash a Nintendo DS ROM.
+ *
+ * @param reader     {{ size: number, read(offset, length): Promise<Uint8Array> }}
+ * @param createMd5  () => { update(bytes): void, hex(): string }
+ * @returns the lowercase hex hash, or null when the file is not a DS ROM.
+ */
+export async function hashNds(reader, createMd5) {
+  if (!reader || reader.size < HEADER_BYTES) return null;
+
+  let origin = 0;
+  let header = await reader.read(0, HEADER_BYTES);
+  if (header.length < HEADER_BYTES) return null;
+
+  if (hasSuperCardHeader(header)) {
+    origin = HEADER_BYTES;
+    if (reader.size < origin + HEADER_BYTES) return null;
+    header = await reader.read(origin, HEADER_BYTES);
+    if (header.length < HEADER_BYTES) return null;
+  }
+
+  const arm9Addr = u32le(header, 0x20);
+  const arm9Size = u32le(header, 0x2c);
+  const arm7Addr = u32le(header, 0x30);
+  const arm7Size = u32le(header, 0x3c);
+  const iconAddr = u32le(header, 0x68);
+
+  // Not a DS ROM (or a corrupt one): refuse instead of reading gigabytes.
+  if (arm9Size + arm7Size > MAX_CODE_BYTES) return null;
+
+  const md5 = createMd5();
+  md5.update(header.subarray(0, HASHED_HEADER));
+  md5.update(await readPadded(reader, arm9Addr + origin, arm9Size));
+  md5.update(await readPadded(reader, arm7Addr + origin, arm7Size));
+  md5.update(await readPadded(reader, iconAddr + origin, ICON_BYTES));
+  return md5.hex();
+}

--- a/mobile/src/hashFile.ts
+++ b/mobile/src/hashFile.ts
@@ -2,10 +2,11 @@
 // RetroAchievements hash through the shared core, the disc rules, or an archive.
 import { unzipSync } from 'fflate';
 // Vendored shared core (source of truth: packages/core).
-import { consoleForExt } from './core';
+import { consoleForExt, hashNds, NDS_EXTS } from './core';
 import { hashDisc, HASHABLE_DISC_EXTS } from './disc';
 import { RandomReader, bufferReader } from './disc/reader';
 import { hashCartCandidates, rulesForExt, Candidate } from './hashCandidates';
+import { md5Create } from './md5';
 import { openFileReader, createTempFile } from './fileIO';
 import { openSevenZip, extractSevenZipEntry, SevenZipError } from './archive/sevenZip';
 import { lzma1Decode } from './lzma/decoder';
@@ -40,10 +41,34 @@ export type Hashed = {
 export const UNSUPPORTED_ARCHIVE_EXTS = new Set(['.rar', '.tar', '.gz', '.bz2', '.xz']);
 export const ARCHIVE_EXTS = new Set(['.zip', '.7z']);
 
+// Every plausible hash for a cartridge file.
+//
+// A Nintendo DS ROM is a container rather than a flat image: RetroAchievements
+// hashes its header plus the ARM9/ARM7 code and icon blocks the header points
+// at (see core/nds.js). A whole-file MD5 of a .nds therefore never matches,
+// which is why DS ROMs used to come back as "no match" on the phone even though
+// the desktop identified them.
+async function cartCandidates(reader: RandomReader, ext: string): Promise<Candidate[]> {
+  let nds: Candidate | null = null;
+  if (NDS_EXTS.has(ext)) {
+    try {
+      const md5 = await hashNds(reader, md5Create);
+      if (md5) nds = { rule: 'nds', md5 };
+    } catch { /* not a DS ROM after all — the cartridge rules below still apply */ }
+  }
+  // For a DS-only extension the whole-file pass is dead weight: it cannot match
+  // anything, and skipping it turns a 128 MB read on the phone into about 1 MB.
+  // `.srl` is shared with Game Boy Advance, so there both hashes are wanted.
+  if (nds && ext !== '.srl') return [nds];
+
+  const rest = await hashCartCandidates(reader, reader.size, rulesForExt(ext));
+  return nds ? [...rest, nds] : rest;
+}
+
 async function hashBytesCandidates(displayName: string, extName: string, bytes: Uint8Array): Promise<Hashed> {
   const ext = extOf(extName);
   const meta = consoleForExt(ext);
-  const candidates = await hashCartCandidates(bufferReader(bytes), bytes.length, rulesForExt(ext));
+  const candidates = await cartCandidates(bufferReader(bytes), ext);
   return {
     name: displayName, ext, rule: meta?.headerRule ?? null,
     consoleId: meta?.consoleId ?? null,
@@ -64,7 +89,7 @@ export async function hashTarget(uri: string, name: string, sizeHint?: number): 
 // that were unpacked to a scratch file).
 async function hashReader(reader: RandomReader, name: string): Promise<Hashed> {
   const ext = extOf(name);
-  const candidates = await hashCartCandidates(reader, reader.size, rulesForExt(ext));
+  const candidates = await cartCandidates(reader, ext);
   const meta = consoleForExt(ext);
   return {
     name, ext, rule: meta?.headerRule ?? null,
@@ -289,6 +314,9 @@ export const CART_EXTS = new Set([
   '.vb', '.vboy', '.min', '.sg', '.sc', '.col', '.cv', '.int', '.itv', '.vec',
   '.gam', '.ws', '.wsc', '.pc2', '.chf', '.sv', '.uze', '.hex', '.arduboy',
   '.wasm', '.mx1', '.mx2', '.rom',
+  // Nintendo DS/DSi. Hashed by the container rule in core/nds.js, not by a
+  // whole-file MD5 — without these the scanner skipped DS ROMs entirely.
+  '.nds', '.dsi', '.ids',
 ]);
 
 // Disc-image formats we recognise. The ones in HASHABLE_DISC_EXTS are hashed

--- a/mobile/src/version.ts
+++ b/mobile/src/version.ts
@@ -1,7 +1,7 @@
 // Single source of truth for the mobile app version + changelog. Mirror the
 // version in app.json ("version" + android.versionCode). The auto-updater
 // compares this against GitHub releases tagged `android-vX.Y.Z`.
-export const APP_VERSION = '0.7.0';
+export const APP_VERSION = '0.7.1';
 
 export const REPO_URL = 'https://github.com/x3kim/RAChecker';
 export const DOCS_URL = 'https://x3kim.github.io/RAChecker/';
@@ -15,6 +15,18 @@ export type ChangelogEntry = { version: string; date: string; en: string[]; de: 
 
 // Newest first. `en`/`de` are bullet lists.
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: '0.7.1',
+    date: '2026-08-18',
+    en: [
+      'Nintendo DS games are found now. A .nds file is a container, not a flat ROM: RetroAchievements hashes its header plus the ARM9/ARM7 code and icon blocks the header points at, so the plain whole-file hash the app used could never match — and DS ROMs were skipped by the folder scan entirely. Both are fixed; the hashes were checked against RAHasher over 14 retail dumps and are identical.',
+      'Security updates for the bundled dependencies.',
+    ],
+    de: [
+      'Nintendo-DS-Spiele werden jetzt gefunden. Eine .nds-Datei ist ein Container, kein flaches ROM: RetroAchievements hasht ihren Header sowie die ARM9-/ARM7-Code- und Icon-Blöcke, auf die der Header zeigt. Der einfache Hash über die ganze Datei, den die App bildete, konnte deshalb nie treffen — und der Ordner-Scan übersprang DS-ROMs ohnehin. Beides behoben; die Hashes wurden an 14 Originaldumps gegen RAHasher geprüft und sind identisch.',
+      'Sicherheits-Updates für die Abhängigkeiten der App.',
+    ],
+  },
   {
     version: '0.7.0',
     date: '2026-08-06',

--- a/packages/core/hash/consoles.js
+++ b/packages/core/hash/consoles.js
@@ -20,6 +20,9 @@ const EXT = {
   '.lnx': { consoleId: 13, headerRule: 'lynx' },
   '.pce': { consoleId: 8,  headerRule: 'pce' },
   '.a78': { consoleId: 51, headerRule: 'a7800' },
+  '.nds': { consoleId: 18, headerRule: null },
+  '.dsi': { consoleId: 78, headerRule: null },
+  '.ids': { consoleId: 18, headerRule: null },
 };
 
 export function consoleForExt(ext) {

--- a/packages/core/hash/nds.js
+++ b/packages/core/hash/nds.js
@@ -1,0 +1,85 @@
+// The RetroAchievements Nintendo DS / DSi hash.
+// Source of truth: rcheevos src/rhash/hash_rom.c, rc_hash_nintendo_ds().
+//
+// Unlike the cartridge rules in rules.js this is not one pass over the file. A
+// DS ROM is a container: its 512-byte header points at an ARM9 code block, an
+// ARM7 code block and an icon/title block, and only those four pieces are
+// hashed — in that order, with everything between them ignored. That is why a
+// plain whole-file MD5 of a .nds never matches RetroAchievements.
+//
+// The byte source is therefore a random-access reader, not a buffer, and MD5 is
+// injected as an incremental accumulator so the identical code runs under Node
+// (crypto) and React Native (js-md5).
+
+// Extensions that carry a DS ROM. `.srl` is shared with Game Boy Advance and
+// `.ids` with DSi, so callers should treat the DS hash as one candidate among
+// others rather than the only answer for those two.
+export const NDS_EXTS = new Set(['.nds', '.dsi', '.ids', '.srl']);
+
+const HEADER_BYTES = 512;   // read; only the first 0x160 are hashed
+const HASHED_HEADER = 0x160;
+const ICON_BYTES = 0xa00;
+// ARM9 + ARM7 are typically well under 1 MB each. rcheevos treats anything past
+// 16 MB as proof this is not a DS ROM rather than trying to read it.
+const MAX_CODE_BYTES = 16 * 1024 * 1024;
+
+// A SuperCard flash cart prepends its own 512-byte header; the real DS header
+// follows it and every address in it is relative to that shifted origin.
+function hasSuperCardHeader(h) {
+  return h[0] === 0x2e && h[1] === 0x00 && h[2] === 0x00 && h[3] === 0xea
+    && h[0xb0] === 0x44 && h[0xb1] === 0x46 && h[0xb2] === 0x96 && h[0xb3] === 0x00;
+}
+
+function u32le(b, at) {
+  return (b[at] | (b[at + 1] << 8) | (b[at + 2] << 16) | (b[at + 3] << 24)) >>> 0;
+}
+
+// Read exactly `length` bytes at `offset`, zero-filling whatever the file does
+// not provide. rcheevos 0-pads a short icon block explicitly; for the code
+// blocks it would hash uninitialised memory, which no real dump reaches and
+// which cannot be reproduced — zeroes keep a truncated file deterministic.
+async function readPadded(reader, offset, length) {
+  const out = new Uint8Array(length);
+  if (offset >= reader.size) return out;
+  const got = await reader.read(offset, Math.min(length, reader.size - offset));
+  out.set(got.subarray(0, Math.min(got.length, length)));
+  return out;
+}
+
+/**
+ * Hash a Nintendo DS ROM.
+ *
+ * @param reader     {{ size: number, read(offset, length): Promise<Uint8Array> }}
+ * @param createMd5  () => { update(bytes): void, hex(): string }
+ * @returns the lowercase hex hash, or null when the file is not a DS ROM.
+ */
+export async function hashNds(reader, createMd5) {
+  if (!reader || reader.size < HEADER_BYTES) return null;
+
+  let origin = 0;
+  let header = await reader.read(0, HEADER_BYTES);
+  if (header.length < HEADER_BYTES) return null;
+
+  if (hasSuperCardHeader(header)) {
+    origin = HEADER_BYTES;
+    if (reader.size < origin + HEADER_BYTES) return null;
+    header = await reader.read(origin, HEADER_BYTES);
+    if (header.length < HEADER_BYTES) return null;
+  }
+
+  const arm9Addr = u32le(header, 0x20);
+  const arm9Size = u32le(header, 0x2c);
+  const arm7Addr = u32le(header, 0x30);
+  const arm7Size = u32le(header, 0x3c);
+  const iconAddr = u32le(header, 0x68);
+
+  // Not a DS ROM (or a corrupt one): refuse instead of reading gigabytes.
+  if (arm9Size + arm7Size > MAX_CODE_BYTES) return null;
+
+  const md5 = createMd5();
+  md5.update(header.subarray(0, HASHED_HEADER));
+  md5.update(await readPadded(reader, arm9Addr + origin, arm9Size));
+  md5.update(await readPadded(reader, arm7Addr + origin, arm7Size));
+  md5.update(await readPadded(reader, iconAddr + origin, ICON_BYTES));
+  return md5.hex();
+}

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,3 +1,4 @@
 export * from './hash/rules.js';
 export * from './hash/consoles.js';
+export * from './hash/nds.js';
 export * from './region.js';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     ".": "./index.js",
     "./hash/rules.js": "./hash/rules.js",
     "./hash/consoles.js": "./hash/consoles.js",
+    "./hash/nds.js": "./hash/nds.js",
     "./region.js": {
       "types": "./region.d.ts",
       "default": "./region.js"

--- a/packages/core/test/mobile-region-mirror.test.js
+++ b/packages/core/test/mobile-region-mirror.test.js
@@ -20,3 +20,13 @@ test('mobile/src/core/region.js is an exact copy of packages/core/region.js', ()
     'Copy packages/core/region.js over mobile/src/core/region.js after changing it.',
   );
 });
+
+test('mobile/src/core/nds.js is an exact copy of packages/core/hash/nds.js', () => {
+  const source = readFileSync(join(ROOT, 'packages', 'core', 'hash', 'nds.js'), 'utf8');
+  const mirror = readFileSync(join(ROOT, 'mobile', 'src', 'core', 'nds.js'), 'utf8');
+  assert.equal(
+    mirror,
+    source,
+    'Copy packages/core/hash/nds.js over mobile/src/core/nds.js after changing it.',
+  );
+});

--- a/packages/core/test/nds.test.js
+++ b/packages/core/test/nds.test.js
@@ -1,0 +1,111 @@
+// The Nintendo DS hash: header + ARM9 + ARM7 + icon, each read at an address the
+// header points at. We can't ship ROMs, so correctness is pinned two ways:
+//
+//   - here, with synthetic ROMs whose expected digest is computed independently
+//     (plain MD5 over the concatenation), which fixes the offsets and the order;
+//   - against RAHasher.exe over 14 real retail dumps (EU/DE, DSi-enhanced), all
+//     byte-identical — e.g. Final Fantasy III (EU) = 435ac50f4dbd02bb4d049228df60418a
+//     and Pokémon SoulSilver (DE) = 1051ea6f1d599812a8a382b2fa4b02b2.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { hashNds, NDS_EXTS } from '../hash/nds.js';
+
+const md5 = () => {
+  const h = createHash('md5');
+  return { update: (b) => h.update(b), hex: () => h.digest('hex') };
+};
+const rawMd5 = (...parts) => {
+  const h = createHash('md5');
+  for (const p of parts) h.update(p);
+  return h.digest('hex');
+};
+
+const reader = (bytes) => ({
+  size: bytes.length,
+  async read(offset, length) { return bytes.subarray(offset, Math.min(bytes.length, offset + length)); },
+});
+
+// Build a DS ROM whose four hashed regions hold distinguishable filler.
+function buildRom({ arm9Size = 0x400, arm7Size = 0x200, superCard = false, iconBytes = 0xa00 } = {}) {
+  const arm9Addr = 0x4000;
+  const arm7Addr = arm9Addr + arm9Size + 0x100;   // deliberate gap: must be skipped
+  const iconAddr = arm7Addr + arm7Size + 0x100;   // another gap
+  const end = iconAddr + iconBytes;
+
+  const header = new Uint8Array(512);
+  for (let i = 0; i < 512; i++) header[i] = i & 0xff;
+  const put = (at, v) => { header[at] = v & 0xff; header[at + 1] = (v >> 8) & 0xff; header[at + 2] = (v >> 16) & 0xff; header[at + 3] = (v >>> 24) & 0xff; };
+  put(0x20, arm9Addr); put(0x2c, arm9Size);
+  put(0x30, arm7Addr); put(0x3c, arm7Size);
+  put(0x68, iconAddr);
+
+  const prefix = superCard ? 512 : 0;
+  const rom = new Uint8Array(prefix + end);
+  if (superCard) {
+    rom[0] = 0x2e; rom[1] = 0x00; rom[2] = 0x00; rom[3] = 0xea;
+    rom[0xb0] = 0x44; rom[0xb1] = 0x46; rom[0xb2] = 0x96; rom[0xb3] = 0x00;
+  }
+  rom.set(header, prefix);
+  const arm9 = new Uint8Array(arm9Size).fill(0xa9);
+  const arm7 = new Uint8Array(arm7Size).fill(0xa7);
+  const icon = new Uint8Array(iconBytes).fill(0x1c);
+  rom.set(arm9, prefix + arm9Addr);
+  rom.set(arm7, prefix + arm7Addr);
+  rom.set(icon, prefix + iconAddr);
+
+  return { rom, header, arm9, arm7, icon };
+}
+
+test('hashes header[0:0x160] + arm9 + arm7 + icon, in that order', async () => {
+  const { rom, header, arm9, arm7, icon } = buildRom();
+  const expected = rawMd5(header.subarray(0, 0x160), arm9, arm7, icon);
+  assert.equal(await hashNds(reader(rom), md5), expected);
+});
+
+test('the gaps between the blocks are not hashed', async () => {
+  // Same ROM twice, the second with every unhashed byte flipped. If the filler
+  // between the blocks leaked into the digest, these would differ.
+  const a = buildRom();
+  const b = buildRom();
+  for (let i = 0x160; i < 0x4000; i++) b.rom[i] = 0xff;                 // header tail + pre-arm9
+  for (let i = 0x4000 + a.arm9.length; i < 0x4000 + a.arm9.length + 0x100; i++) b.rom[i] = 0xff;
+  assert.equal(await hashNds(reader(b.rom), md5), await hashNds(reader(a.rom), md5));
+});
+
+test('only the first 352 bytes of the header count', async () => {
+  const a = buildRom();
+  const b = buildRom();
+  b.rom[0x15f] = b.rom[0x15f] ^ 0xff;   // inside the hashed range -> must change
+  assert.notEqual(await hashNds(reader(b.rom), md5), await hashNds(reader(a.rom), md5));
+});
+
+test('a SuperCard header is skipped and every address is relative to it', async () => {
+  const plain = buildRom();
+  const sc = buildRom({ superCard: true });
+  assert.equal(await hashNds(reader(sc.rom), md5), await hashNds(reader(plain.rom), md5));
+});
+
+test('a short icon block is zero-padded to 2560 bytes', async () => {
+  const short = buildRom({ iconBytes: 0x40 });          // homebrew: truncated icon
+  const padded = new Uint8Array(0xa00);
+  padded.set(short.icon);
+  const expected = rawMd5(short.header.subarray(0, 0x160), short.arm9, short.arm7, padded);
+  assert.equal(await hashNds(reader(short.rom), md5), expected);
+});
+
+test('refuses a file whose code sizes exceed 16 MB (not a DS ROM)', async () => {
+  const { rom } = buildRom();
+  rom[0x2c] = 0x00; rom[0x2d] = 0x00; rom[0x2e] = 0x00; rom[0x2f] = 0x01; // arm9 = 16 MB
+  rom[0x3c] = 0x00; rom[0x3d] = 0x00; rom[0x3e] = 0x00; rom[0x3f] = 0x01; // arm7 = 16 MB
+  assert.equal(await hashNds(reader(rom), md5), null);
+});
+
+test('refuses a file too small to hold a header', async () => {
+  assert.equal(await hashNds(reader(new Uint8Array(16)), md5), null);
+});
+
+test('NDS_EXTS covers the DS extensions, including the ones shared with other systems', () => {
+  for (const e of ['.nds', '.dsi', '.ids', '.srl']) assert.ok(NDS_EXTS.has(e), e);
+  assert.ok(!NDS_EXTS.has('.gba'));
+});


### PR DESCRIPTION
The Android app could not match a **single** Nintendo DS game. Fixes that, and picks up the mobile dependency updates that are actually safe.

## Why DS never worked

Two independent reasons, either one enough on its own:

1. `.nds` was missing from `CART_EXTS`, so the folder scanner never surfaced those files at all.
2. `EXT_RULES` mapped `.nds` to no rule, leaving a plain whole-file MD5.

The second one can never match. A DS ROM is a **container**, not a flat image — RetroAchievements hashes only four regions, each at an address its header points at:

| region | size |
|---|---|
| header | first `0x160` bytes of the 512-byte header |
| ARM9 code | from `header[0x20]`, length `header[0x2C]` |
| ARM7 code | from `header[0x30]`, length `header[0x3C]` |
| icon / title | from `header[0x68]`, `0xA00` bytes, zero-padded if short |

Everything between those blocks is ignored, which is exactly why hashing the whole file gives an unrelated digest.

## What this adds

`packages/core/hash/nds.js` ports `rc_hash_nintendo_ds` from rcheevos (`src/rhash/hash_rom.c`): a random-access reader in, an injected incremental MD5 out, so one file runs under both Node and React Native. Vendored to `mobile/src/core/nds.js` as an exact copy with a mirror test, the same way `region.js` is already guarded against drift.

`cartCandidates()` adds the DS hash as a candidate for `.nds/.dsi/.ids/.srl`. For the DS-only extensions it **replaces** the whole-file pass instead of adding to it — that hash cannot match anything, and skipping it turns a 128 MB read on the phone into roughly 1 MB. `.srl` is shared with Game Boy Advance, so there both hashes are kept and the hash-DB lookup decides which system it is.

## Verification

Checked against the bundled `RAHasher.exe` over **14 real retail dumps** (EU/DE, including DSi-enhanced titles) — byte identical in every case, both through Node's crypto and through the phone's own `js-md5`:

```
435ac50f4dbd02bb4d049228df60418a  Final Fantasy III (EU)
1051ea6f1d599812a8a382b2fa4b02b2  Pokémon SoulSilver (DE)
548a0f1314a3d210686976b278d0fac1  Pokémon Schwarze Edition (DE, NDSi Enhanced)
…11 more, all matching
```

Plus nine unit tests pinning the offsets, the block ordering, the SuperCard header, icon zero-padding and the 16 MB sanity check; 106/106 green. `npx tsc --noEmit` clean and `expo export --platform android` bundles without error (the DS extensions are present in the emitted Hermes bundle).

## Security

`npm audit fix` (**no** `--force`) in `mobile/` picks up the fixable transitives: expo 57.0.8 → 57.0.14, plus js-yaml, nanoid, brace-expansion and postcss. `package.json` is untouched and react-native stays on 0.86.0.

**Deliberately not applied:** npm offers "fixes" for `expo`, `react-native` and `expo-sharing` that are *downgrades* — to Expo 53 and RN 0.72 — which would break the app outright. The two genuine advisories that remain are:

- `image-size` ← `metro` (the bundler)
- `uuid` ← `xcode` (the iOS project generator)

Both are build tooling; neither ships inside the Android APK, and 57.0.14 is already the newest SDK 57 patch. The Dependabot config added in #12 will surface the real fix once Expo bumps them upstream.

## Release

`mobile/app.json` and `mobile/src/version.ts` go to **0.7.1 / versionCode 11**, with a changelog entry in both languages. Pushing an `android-v0.7.1` tag triggers the EAS build and publishes the APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable reliable Nintendo DS ROM discovery and matching in the mobile app, and prepare the 0.7.1 Android release with safe dependency updates.

New Features:
- Add Nintendo DS, DSi, and related ROM discovery and RetroAchievements-compatible hashing to the mobile scanner.
- Release mobile version 0.7.1 with Android versionCode 11 and bilingual changelog updates.

Bug Fixes:
- Fix mobile scanning and matching of Nintendo DS ROMs by recognizing their extensions and using container-aware hashes instead of whole-file MD5s.

Enhancements:
- Share the Nintendo DS hashing implementation between the core package and mobile app while guarding the vendored copy against drift.
- Preserve competing hash candidates for extensions shared with other cartridge systems and avoid unnecessary whole-file reads for DS-only files.

Build:
- Update mobile dependency lockfile with safe security fixes while retaining the existing Expo and React Native versions.

Deployment:
- Prepare Android release 0.7.1 for tagged EAS builds and APK publication.

Tests:
- Add Nintendo DS hashing coverage for block selection, ignored gaps, SuperCard headers, icon padding, size validation, and supported extensions.
- Add a mirror test ensuring the mobile Nintendo DS hashing implementation matches the shared core source.