### PR TITLE
GameCube/Wii images: hash Dolphin's .rvz and .wia (desktop 0.15.0)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -253,6 +253,12 @@ Der automatische Download geht nur unter Windows. Unter Linux/macOS RAHasher sel
 
 **Android** braucht keinen RAHasher — die Disc-Regeln sind direkt in der App umgesetzt.
 
+**Komprimierte Container, die RAHasher nicht öffnen kann** — `.cso`/`.zso` (PSP, PS2) und
+Dolphins `.rvz`/`.wia` (GameCube, Wii) — werden für die Dauer des Hashens in eine echte `.iso`
+im Temp-Ordner ausgepackt und danach wieder entfernt. Der Hash ist derselbe wie beim
+unkomprimierten Image. `.rvz`/`.wia` mit bzip2, LZMA oder LZMA2 werden als nicht unterstützt
+gemeldet — in Dolphin mit **Zstandard** neu komprimieren, der Voreinstellung.
+
 ---
 
 ## Konfiguration

--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ The automatic download is Windows-only. On Linux/macOS, build RAHasher yourself 
 
 **Android** doesn't need RAHasher — the disc rules are implemented natively in the app.
 
+**Compressed containers RAHasher cannot open** — `.cso`/`.zso` (PSP, PS2) and Dolphin's
+`.rvz`/`.wia` (GameCube, Wii) — are expanded into a plain `.iso` in the temp folder for the
+moment it takes to hash, then removed again. The hash is the one the raw image produces.
+`.rvz`/`.wia` written with bzip2, LZMA or LZMA2 are reported as unsupported; re-compress them
+in Dolphin with **Zstandard**, which is what it defaults to.
+
 ---
 
 ## Configuration

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,6 +16,11 @@ Tab **Hash-DB** → **Synchronisieren** (oder **Komplett neu** für ein vollstä
 Nur nötig für Disc-Systeme (PS1/PS2/PSP/Saturn/Dreamcast/…) und `.chd`.
 Tab **Einstellungen** → **RAHasher herunterladen.** Cartridge-Systeme funktionieren ohne.
 
+Komprimierte Container, die RAHasher nicht öffnet — `.cso`/`.zso` und Dolphins `.rvz`/`.wia` —
+packt RAChecker zum Hashen kurz in eine echte `.iso` aus und räumt sie danach wieder weg.
+`.rvz`/`.wia` mit bzip2, LZMA oder LZMA2 werden als nicht unterstützt gemeldet; in Dolphin mit
+**Zstandard** neu komprimieren (Voreinstellung).
+
 ## 3. Bibliothek scannen
 Tab **Scannen**:
 1. **ROM-Oberordner** wählen (beim allerersten Start füllt der Onboarding-Assistent ihn, sonst leer) —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "description": "RetroAchievements ROM Compatibility Checker — scan your ROM library and find which games can earn achievements.",

--- a/server/src/consoles.js
+++ b/server/src/consoles.js
@@ -27,10 +27,10 @@ export const CONSOLES = [
   { id: 13, short: 'lynx',  name: 'Atari Lynx',                method: 'file',     headerRule: 'lynx',    exts: ['.lnx', '.lyx'] },
   { id: 14, short: 'ngp',   name: 'Neo Geo Pocket',            method: 'file',     headerRule: null,      exts: ['.ngp', '.ngc', '.npc'] },
   { id: 15, short: 'gg',    name: 'Game Gear',                 method: 'file',     headerRule: null,      exts: ['.gg'] },
-  { id: 16, short: 'gc',    name: 'GameCube',                  method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.gcm', '.gcz', '.ciso'] },
+  { id: 16, short: 'gc',    name: 'GameCube',                  method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.wia', '.gcm', '.gcz', '.ciso'] },
   { id: 17, short: 'jag',   name: 'Atari Jaguar',              method: 'file',     headerRule: null,      exts: ['.j64', '.jag', '.rom', '.abs', '.cof'] },
   { id: 18, short: 'ds',    name: 'Nintendo DS',               method: 'rahasher', headerRule: null,      exts: ['.nds', '.srl', '.ids'] },
-  { id: 19, short: 'wii',   name: 'Wii',                       method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.wbfs', '.wad'] },
+  { id: 19, short: 'wii',   name: 'Wii',                       method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.wia', '.wbfs', '.wad'] },
   { id: 21, short: 'ps2',   name: 'PlayStation 2',             method: 'rahasher', headerRule: null,      exts: ['.iso', '.chd', '.cue', '.bin', '.m3u', '.cso'] },
   { id: 23, short: 'mo2',   name: 'Magnavox Odyssey 2',        method: 'file',     headerRule: null,      exts: ['.bin'] },
   { id: 24, short: 'mini',  name: 'Pokemon Mini',              method: 'file',     headerRule: null,      exts: ['.min'] },
@@ -151,7 +151,7 @@ export const EXT_TO_CONSOLES = (() => {
 
 export const ARCHIVE_EXTS = new Set(['.zip', '.7z', '.rar', '.gz', '.tar', '.tgz']);
 // Disc/playlist containers that should go straight to RAHasher, never extracted.
-export const DISC_EXTS = new Set(['.cue', '.bin', '.iso', '.chd', '.pbp', '.m3u', '.gdi', '.cdi', '.toc', '.ccd', '.img', '.rvz', '.cso', '.zso', '.wbfs', '.gcm', '.gcz', '.ciso', '.nrg']);
+export const DISC_EXTS = new Set(['.cue', '.bin', '.iso', '.chd', '.pbp', '.m3u', '.gdi', '.cdi', '.toc', '.ccd', '.img', '.rvz', '.wia', '.cso', '.zso', '.wbfs', '.gcm', '.gcz', '.ciso', '.nrg']);
 
 export function consoleMethod(id) {
   return CONSOLE_BY_ID.get(id)?.method ?? 'unknown';

--- a/server/src/hashing/expand.js
+++ b/server/src/hashing/expand.js
@@ -1,0 +1,26 @@
+// Compressed disc containers RAHasher cannot open on its own.
+//
+// RAHasher only reads raw images, so a .cso/.zso or .rvz/.wia is expanded into a
+// plain .iso in temp first and removed again straight after hashing. Both paths
+// return the same shape, so callers only need this one entry point.
+import { isCsoPath, expandCso } from './cso.js';
+import { isRvzPath, expandRvz } from './rvz.js';
+
+export function isCompressedDisc(filePath) {
+  return isCsoPath(filePath) || isRvzPath(filePath);
+}
+
+/**
+ * Expand a compressed disc image. `displayPath` decides which format to try —
+ * it differs from `filePath` when the image was extracted from an archive into a
+ * temp file with a generic name.
+ *
+ * Returns { path, cleanup } on success, { error } when it cannot be read, or
+ * null when the file is not a compressed container at all.
+ */
+export async function expandDiscImage(filePath, displayPath, options) {
+  const name = displayPath ?? filePath;
+  if (isCsoPath(name)) return expandCso(filePath, options);
+  if (isRvzPath(name)) return expandRvz(filePath, options);
+  return null;
+}

--- a/server/src/hashing/index.js
+++ b/server/src/hashing/index.js
@@ -5,7 +5,7 @@ import { CONSOLE_BY_ID } from '../consoles.js';
 import { hashFile, hashBuffer, md5 } from './file-hash.js';
 import { readEntry } from './archive.js';
 import { hashWithRAHasher, isRAHasherAvailable } from './rahasher.js';
-import { isCsoPath, expandCso } from './cso.js';
+import { isCompressedDisc, expandDiscImage } from './expand.js';
 
 // FBNeo parent-folder names that get prefixed into the arcade name hash.
 const ARCADE_KNOWN_PARENTS = new Set([
@@ -82,27 +82,30 @@ export async function hashTarget({ filePath, consoleId, entry, signal, onPhase, 
       try {
         const target = r.tempPath;
         if (!target) return { status: 'error', message: 'Could not extract disc image from archive.' };
-        return await rahasherWithCso(consoleId, target, entry.name, { signal, timeoutMs, phase });
+        return await rahasherWithExpansion(consoleId, target, entry.name, { signal, timeoutMs, phase });
       } finally {
         await r.cleanup?.();
       }
     }
-    return await rahasherWithCso(consoleId, filePath, filePath, { signal, timeoutMs, phase });
+    return await rahasherWithExpansion(consoleId, filePath, filePath, { signal, timeoutMs, phase });
   }
 
   return { status: 'error', message: `No hashing method for ${c.name}` };
 }
 
-// Run RAHasher against a disc image, expanding compressed ISOs first. RAHasher
-// cannot read .cso/.zso ("Could not open track"), so those are unpacked into a
-// plain .iso in temp and removed again straight after hashing — the hash is the
-// same one RAHasher would produce for the uncompressed image.
-async function rahasherWithCso(consoleId, filePath, displayPath, { signal, timeoutMs, phase }) {
+// Run RAHasher against a disc image, expanding compressed ones first. RAHasher
+// cannot read .cso/.zso ("Could not open track") or Dolphin's .rvz/.wia, so
+// those are unpacked into a plain .iso in temp and removed again straight after
+// hashing — the hash is the same one RAHasher would produce for the raw image.
+async function rahasherWithExpansion(consoleId, filePath, displayPath, { signal, timeoutMs, phase }) {
   let target = filePath;
   let cleanup = null;
-  if (isCsoPath(displayPath)) {
+  if (isCompressedDisc(displayPath)) {
     phase('extracting', 0, 0);
-    const expanded = await expandCso(filePath, { signal, onProgress: (d, t) => phase('extracting', d, t) });
+    const expanded = await expandDiscImage(filePath, displayPath, {
+      signal,
+      onProgress: (d, t) => phase('extracting', d, t),
+    });
     if (expanded?.error) return { status: 'error', message: expanded.error };
     if (expanded?.path) { target = expanded.path; cleanup = expanded.cleanup; }
   }

--- a/server/src/hashing/rvz.js
+++ b/server/src/hashing/rvz.js
@@ -1,0 +1,597 @@
+// WIA/RVZ (Dolphin's compressed GameCube/Wii disc images) support.
+//
+// RAHasher only understands raw disc images, so an .rvz/.wia is expanded back
+// into a plain .iso in the temp folder and *that* is handed to RAHasher —
+// exactly the trick cso.js plays for .cso/.zso. The expansion is lossless, so
+// the hash is the one RAHasher would have produced for the original dump.
+//
+// The format (Dolphin's docs/WiaAndRvz.md; every integer is big-endian) stores
+// the disc as fixed-size chunks called "groups":
+//
+//   0x00  wia_file_head_t   magic "WIA\1"/"RVZ\1", ISO size, offsets
+//   0x48  wia_disc_t        disc type, compression, chunk size, the first 0x80
+//                           bytes of the disc, and where the three tables live
+//   ...   wia_part_t[]      one per Wii partition: title key + two data runs
+//   ...   wia_raw_data_t[]  the parts of the disc that are stored verbatim
+//   ...   wia_group_t[]     where each group's payload sits in the file
+//
+// Two things are *not* stored the way they appear on the disc and have to be
+// reconstructed here:
+//
+//   - Wii partition data is kept decrypted and with its hash tree stripped, so
+//     the H0/H1/H2 hashes are recomputed and the sectors re-encrypted with the
+//     partition's title key (rebuildWiiGroup below).
+//   - RVZ "packing" replaces the pseudo-random padding Nintendo's mastering
+//     wrote across unused areas with a 68-byte seed for the lagged-Fibonacci
+//     generator that produced it (decodeRvzPacking below).
+//
+// Everything is done one group at a time: a 4.7 GB Wii disc would not fit in a
+// Buffer, let alone in memory.
+import { open, stat, unlink, statfs } from 'node:fs/promises';
+import { join, basename, extname } from 'node:path';
+import { createHash, createCipheriv } from 'node:crypto';
+import { zstdDecompressSync } from 'node:zlib';
+import { config } from '../config.js';
+
+export const RVZ_EXTS = new Set(['.rvz', '.wia']);
+
+export function isRvzPath(filePath) {
+  return RVZ_EXTS.has(extname(String(filePath)).toLowerCase());
+}
+
+const FILE_HEAD_SIZE = 0x48;
+const DISC_SIZE = 0xdc;
+const PART_ENTRY_SIZE = 0x30;
+const RAW_DATA_ENTRY_SIZE = 0x18;
+
+const DISC_TYPE_WII = 2;
+
+const COMPRESSION = { NONE: 0, PURGE: 1, BZIP2: 2, LZMA: 3, LZMA2: 4, ZSTD: 5 };
+const COMPRESSION_NAMES = ['none', 'Purge', 'bzip2', 'LZMA', 'LZMA2', 'Zstandard'];
+// Node ships a Zstandard decoder; bzip2/LZMA/LZMA2 would each need a decoder of
+// their own. Zstandard is what Dolphin defaults to, so those three are rare.
+const SUPPORTED_COMPRESSION = new Set([COMPRESSION.NONE, COMPRESSION.PURGE, COMPRESSION.ZSTD]);
+
+// Wii disc geometry. A sector is 0x8000 bytes on disc: a 0x400 hash block
+// followed by 0x7c00 bytes of encrypted payload.
+const SECTOR_SIZE = 0x8000;
+const SECTOR_DATA_SIZE = 0x7c00;
+const SECTOR_HASH_SIZE = 0x400;
+const SECTORS_PER_SUBGROUP = 8;
+const SUBGROUPS_PER_GROUP = 8;
+const SECTORS_PER_GROUP = SECTORS_PER_SUBGROUP * SUBGROUPS_PER_GROUP; // 64
+const WII_GROUP_SIZE = SECTORS_PER_GROUP * SECTOR_SIZE; // 0x200000
+
+async function readExact(fh, size, position) {
+  const buf = Buffer.alloc(size);
+  let got = 0;
+  while (got < size) {
+    const { bytesRead } = await fh.read(buf, got, size - got, position + got);
+    if (bytesRead === 0) throw new Error(`file ends at ${position + got}, wanted ${position + size}`);
+    got += bytesRead;
+  }
+  return buf;
+}
+
+// Whole-stream codecs. PURGE is not one of these — it is a sparse-segment
+// encoding applied to the group payload itself, decoded by decodePurge.
+function decompressStream(method, input) {
+  if (method === COMPRESSION.NONE) return input;
+  if (method === COMPRESSION.ZSTD) return zstdDecompressSync(input);
+  throw new Error(`compression method ${COMPRESSION_NAMES[method] ?? method} is not supported`);
+}
+
+// PURGE (WIA only): a run of {offset, size, data} segments covering the parts of
+// the group that are not zero, then a SHA-1 of everything before it.
+function decodePurge(input, outputSize) {
+  const out = Buffer.alloc(outputSize);
+  let pos = 0;
+  while (pos + 8 <= input.length - 20) {
+    const offset = input.readUInt32BE(pos);
+    const size = input.readUInt32BE(pos + 4);
+    pos += 8;
+    if (size === 0) continue;
+    if (offset + size > outputSize || pos + size > input.length) throw new Error('Purge segment out of range');
+    input.copy(out, offset, pos, pos + size);
+    pos += size;
+  }
+  return out;
+}
+
+// The lagged Fibonacci generator (f = xor, j = 32, k = 521) that produced the
+// padding Nintendo's disc mastering wrote into unused areas. RVZ throws that
+// padding away and keeps only the 68-byte seed, so it has to be replayed here.
+const LFG_WORDS = 521;
+const LFG_LAG = 32;
+const LFG_SEED_WORDS = 17;
+// Bits 16-17 of each word never reach the output and bits 24-25 appear twice —
+// a quirk of the original generator that has to be reproduced exactly.
+const LFG_BYTE_SHIFTS = [24, 18, 8, 0];
+
+class JunkGenerator {
+  constructor(seed) {
+    this.buffer = new Uint32Array(LFG_WORDS);
+    for (let i = 0; i < LFG_SEED_WORDS; i++) this.buffer[i] = seed.readUInt32BE(i * 4);
+    for (let i = LFG_SEED_WORDS; i < LFG_WORDS; i++) {
+      this.buffer[i] =
+        (((this.buffer[i - 17] << 23) >>> 0) ^ (this.buffer[i - 16] >>> 9) ^ this.buffer[i - 1]) >>> 0;
+    }
+    this.position = 0;
+    for (let i = 0; i < 4; i++) this.advance(); // the generator always runs four rounds first
+  }
+
+  advance() {
+    const buf = this.buffer;
+    for (let i = 0; i < LFG_LAG; i++) buf[i] = (buf[i] ^ buf[i + LFG_WORDS - LFG_LAG]) >>> 0;
+    for (let i = LFG_LAG; i < LFG_WORDS; i++) buf[i] = (buf[i] ^ buf[i - LFG_LAG]) >>> 0;
+  }
+
+  nextByte() {
+    const byte = (this.buffer[this.position >>> 2] >>> LFG_BYTE_SHIFTS[this.position & 3]) & 0xff;
+    this.position++;
+    if (this.position === LFG_WORDS * 4) {
+      this.advance();
+      this.position = 0;
+    }
+    return byte;
+  }
+
+  // Fill `out[start..start+size)` with the next `size` bytes of padding.
+  fill(out, start, size) {
+    for (let i = 0; i < size; i++) out[start + i] = this.nextByte();
+  }
+
+  skip(count) {
+    for (let i = 0; i < count; i++) this.nextByte();
+  }
+}
+
+// A seed describes the padding from the start of its 0x8000-byte sector, so a
+// run starting mid-sector has to throw away the bytes before it.
+function junkGeneratorAt(seed, discOffset) {
+  const gen = new JunkGenerator(seed);
+  const misalignment = discOffset % SECTOR_SIZE;
+  if (misalignment !== 0) gen.skip(misalignment);
+  return gen;
+}
+
+// RVZ packing: a stream of [u32 size, msb = "this is padding"] headers, each
+// followed either by `size` literal bytes or by a 68-byte generator seed.
+function decodeRvzPacking(input, outputSize, baseDiscOffset) {
+  const out = Buffer.alloc(outputSize);
+  let inPos = 0;
+  let outPos = 0;
+  while (outPos < outputSize) {
+    if (inPos + 4 > input.length) throw new Error('RVZ packing stream ended early');
+    const header = input.readUInt32BE(inPos);
+    inPos += 4;
+    const isJunk = (header & 0x80000000) !== 0;
+    const size = header & 0x7fffffff;
+    if (size === 0 || outPos + size > outputSize) throw new Error('RVZ packing run out of range');
+    if (isJunk) {
+      junkGeneratorAt(input.subarray(inPos, inPos + 68), baseDiscOffset + outPos).fill(out, outPos, size);
+      inPos += 68;
+    } else {
+      input.copy(out, outPos, inPos, inPos + size);
+      inPos += size;
+    }
+    outPos += size;
+  }
+  return out;
+}
+
+function sha1(buf) {
+  return createHash('sha1').update(buf).digest();
+}
+
+// Rebuild one 64-sector Wii group: recompute the hash tree over the decrypted
+// payload, apply the recorded exceptions, then encrypt sectors and hash blocks
+// with the partition's title key.
+//
+// `data` always holds a full group (short groups are zero-padded) because the
+// H1/H2 hashes of a trailing partial group still cover all 64 nominal sectors,
+// exactly as a real disc does. Only `sectorCount` sectors are written out.
+//
+// Hash block layout, per 0x400-byte block:
+//   0x000  H0: SHA-1 of each of the sector's 31 0x400-byte data blocks
+//   0x280  H1: SHA-1 of every H0 array in the 8-sector subgroup
+//   0x340  H2: SHA-1 of every H1 array in the 64-sector group
+const H0_COUNT = 31;
+const H0_SIZE = H0_COUNT * 20; // 0x26c
+const H1_OFFSET = 0x280;
+const H1_SIZE = SECTORS_PER_SUBGROUP * 20; // 0xa0
+const H2_OFFSET = 0x340;
+
+function rebuildWiiGroup(data, sectorCount, titleKey, exceptions) {
+  const hashBlocks = [];
+  for (let s = 0; s < SECTORS_PER_GROUP; s++) {
+    const block = Buffer.alloc(SECTOR_HASH_SIZE);
+    const sector = data.subarray(s * SECTOR_DATA_SIZE, (s + 1) * SECTOR_DATA_SIZE);
+    for (let i = 0; i < H0_COUNT; i++) {
+      sha1(sector.subarray(i * 0x400, (i + 1) * 0x400)).copy(block, i * 20);
+    }
+    hashBlocks.push(block);
+  }
+
+  for (let sub = 0; sub < SUBGROUPS_PER_GROUP; sub++) {
+    const base = sub * SECTORS_PER_SUBGROUP;
+    const h1 = Buffer.alloc(H1_SIZE);
+    for (let i = 0; i < SECTORS_PER_SUBGROUP; i++) {
+      sha1(hashBlocks[base + i].subarray(0, H0_SIZE)).copy(h1, i * 20);
+    }
+    for (let i = 0; i < SECTORS_PER_SUBGROUP; i++) h1.copy(hashBlocks[base + i], H1_OFFSET);
+  }
+
+  const h2 = Buffer.alloc(SUBGROUPS_PER_GROUP * 20);
+  for (let sub = 0; sub < SUBGROUPS_PER_GROUP; sub++) {
+    const h1 = hashBlocks[sub * SECTORS_PER_SUBGROUP].subarray(H1_OFFSET, H1_OFFSET + H1_SIZE);
+    sha1(h1).copy(h2, sub * 20);
+  }
+  for (let s = 0; s < SECTORS_PER_GROUP; s++) h2.copy(hashBlocks[s], H2_OFFSET);
+
+  // Sectors whose real hash block differs from what the tree computes (the disc
+  // is signed over these, so a mismatch has to be preserved verbatim).
+  for (const ex of exceptions) {
+    if (ex.sector < SECTORS_PER_GROUP) ex.hash.copy(hashBlocks[ex.sector], ex.offset);
+  }
+
+  const out = Buffer.alloc(sectorCount * SECTOR_SIZE);
+  const zeroIv = Buffer.alloc(16);
+  for (let s = 0; s < sectorCount; s++) {
+    const hashCipher = createCipheriv('aes-128-cbc', titleKey, zeroIv).setAutoPadding(false);
+    const encryptedHash = Buffer.concat([hashCipher.update(hashBlocks[s]), hashCipher.final()]);
+    // The payload's IV is the last 16 bytes of the encrypted hash block.
+    const dataIv = encryptedHash.subarray(0x3d0, 0x3e0);
+    const dataCipher = createCipheriv('aes-128-cbc', titleKey, dataIv).setAutoPadding(false);
+    const payload = data.subarray(s * SECTOR_DATA_SIZE, (s + 1) * SECTOR_DATA_SIZE);
+    const encryptedData = Buffer.concat([dataCipher.update(payload), dataCipher.final()]);
+    encryptedHash.copy(out, s * SECTOR_SIZE);
+    encryptedData.copy(out, s * SECTOR_SIZE + SECTOR_HASH_SIZE);
+  }
+  return out;
+}
+
+// Parse the file header, the disc header and the three tables. Returns null when
+// the file is not a WIA/RVZ at all, so the caller can hash it as before.
+async function readRvzHeader(fh) {
+  const head = await readExact(fh, FILE_HEAD_SIZE, 0);
+  const magic = head.toString('latin1', 0, 4);
+  if (magic !== 'WIA\x01' && magic !== 'RVZ\x01') return null;
+
+  const isRvz = magic === 'RVZ\x01';
+  const isoSize = Number(head.readBigUInt64BE(0x24));
+  const discFieldSize = head.readUInt32BE(0x0c);
+
+  // wia_disc_t may be shorter than we know about in an older file; pad it out so
+  // the field offsets below stay valid.
+  const disc = Buffer.alloc(DISC_SIZE);
+  (await readExact(fh, Math.min(Math.max(discFieldSize, 1), DISC_SIZE), FILE_HEAD_SIZE)).copy(disc);
+
+  const ctx = {
+    isRvz,
+    isoSize,
+    discType: disc.readUInt32BE(0x00),
+    compression: disc.readUInt32BE(0x04),
+    chunkSize: disc.readUInt32BE(0x0c),
+    discHead: Buffer.from(disc.subarray(0x10, 0x90)),
+    groupEntrySize: isRvz ? 12 : 8,
+  };
+
+  if (!Number.isSafeInteger(isoSize) || isoSize <= 0) throw new Error('implausible ISO size');
+  // WIA chunks are multiples of 2 MiB, RVZ chunks a power of two of at least
+  // 32 KiB. Both must divide into whole sectors for the partition maths below.
+  const { chunkSize } = ctx;
+  const chunkOk = isRvz
+    ? chunkSize >= SECTOR_SIZE && chunkSize <= (64 << 20) && (chunkSize & (chunkSize - 1)) === 0
+    : chunkSize > 0 && chunkSize % WII_GROUP_SIZE === 0;
+  if (!chunkOk) throw new Error(`implausible chunk size ${chunkSize}`);
+
+  const numParts = disc.readUInt32BE(0x90);
+  const partEntrySize = disc.readUInt32BE(0x94) || PART_ENTRY_SIZE;
+  const partOffset = Number(disc.readBigUInt64BE(0x98));
+  const numRawData = disc.readUInt32BE(0xb4);
+  const rawDataOffset = Number(disc.readBigUInt64BE(0xb8));
+  const rawDataSize = disc.readUInt32BE(0xc0);
+  const numGroups = disc.readUInt32BE(0xc4);
+  const groupOffset = Number(disc.readBigUInt64BE(0xc8));
+  const groupSize = disc.readUInt32BE(0xd0);
+
+  if (!SUPPORTED_COMPRESSION.has(ctx.compression)) {
+    const name = COMPRESSION_NAMES[ctx.compression] ?? `type ${ctx.compression}`;
+    const err = new Error(
+      `this image is compressed with ${name}; RAChecker can only read Zstandard-compressed ones. ` +
+      'Re-compress it in Dolphin (Convert File… → Zstandard) and scan it again'
+    );
+    err.unsupportedCompression = true;
+    throw err;
+  }
+
+  // The partition table is stored uncompressed; the other two are compressed
+  // with the disc's own compression method.
+  ctx.parts = [];
+  if (numParts > 0) {
+    const buf = await readExact(fh, numParts * partEntrySize, partOffset);
+    for (let i = 0; i < numParts; i++) {
+      const entry = Buffer.alloc(PART_ENTRY_SIZE);
+      buf.copy(entry, 0, i * partEntrySize, i * partEntrySize + Math.min(partEntrySize, PART_ENTRY_SIZE));
+      const runs = [];
+      for (let r = 0; r < 2; r++) {
+        const o = 16 + r * 16;
+        runs.push({
+          firstSector: entry.readUInt32BE(o),
+          numSectors: entry.readUInt32BE(o + 4),
+          groupIndex: entry.readUInt32BE(o + 8),
+          numGroups: entry.readUInt32BE(o + 12),
+        });
+      }
+      ctx.parts.push({ key: Buffer.from(entry.subarray(0, 16)), runs });
+    }
+  }
+
+  const readTable = async (offset, packedSize, expected) => {
+    const raw = await readExact(fh, packedSize, offset);
+    const table = decompressStream(ctx.compression, raw);
+    if (table.length < expected) throw new Error('a table decompressed to fewer bytes than it declares');
+    return table;
+  };
+
+  ctx.rawData = [];
+  if (numRawData > 0) {
+    const table = await readTable(rawDataOffset, rawDataSize, numRawData * RAW_DATA_ENTRY_SIZE);
+    for (let i = 0; i < numRawData; i++) {
+      const o = i * RAW_DATA_ENTRY_SIZE;
+      ctx.rawData.push({
+        offset: Number(table.readBigUInt64BE(o)),
+        size: Number(table.readBigUInt64BE(o + 8)),
+        groupIndex: table.readUInt32BE(o + 16),
+        numGroups: table.readUInt32BE(o + 20),
+      });
+    }
+  }
+
+  ctx.groups = [];
+  if (numGroups > 0) {
+    const table = await readTable(groupOffset, groupSize, numGroups * ctx.groupEntrySize);
+    for (let i = 0; i < numGroups; i++) {
+      const o = i * ctx.groupEntrySize;
+      ctx.groups.push({
+        dataOffset: table.readUInt32BE(o) * 4,
+        dataSize: table.readUInt32BE(o + 4),
+        packedSize: ctx.groupEntrySize >= 12 ? table.readUInt32BE(o + 8) : 0,
+      });
+    }
+  }
+
+  return ctx;
+}
+
+// Decode one group into `logicalSize` plain bytes. `exceptionLists` is 0 for raw
+// data and >= 1 for Wii partition data, where each list prefixes the payload.
+async function decodeGroup(ctx, fh, index, { logicalSize, exceptionLists, baseDiscOffset, firstSector }) {
+  const group = ctx.groups[index];
+  if (!group) throw new Error(`group ${index} is past the end of the group table`);
+
+  const compressed = ctx.isRvz ? (group.dataSize & 0x80000000) !== 0 : ctx.compression !== COMPRESSION.NONE;
+  const storedSize = ctx.isRvz ? group.dataSize & 0x7fffffff : group.dataSize;
+  // A group with no stored data is a run of zeroes.
+  if (storedSize === 0) return { payload: Buffer.alloc(logicalSize), exceptions: [] };
+
+  const method = compressed ? ctx.compression : COMPRESSION.NONE;
+  const raw = await readExact(fh, storedSize, group.dataOffset);
+  // Purge is applied to the payload only, so its exception lists sit in front of
+  // the still-encoded data rather than inside a decompressed stream.
+  const stream = method === COMPRESSION.PURGE ? raw : decompressStream(method, raw);
+
+  let pos = 0;
+  const exceptions = [];
+  if (exceptionLists > 0) {
+    // A chunk carries one list per 2 MiB of disc "even for a wia_group_t which
+    // contains less data than normal due to it being at the end of a partition",
+    // so a list always covers 64 sectors — or the whole chunk when the chunk is
+    // smaller than that. Deriving it from `logicalSize` would misplace every
+    // exception in the last, short chunk of a run.
+    const sectorsPerList = Math.min(SECTORS_PER_GROUP, ctx.chunkSize / SECTOR_SIZE);
+    for (let i = 0; i < exceptionLists; i++) {
+      const count = stream.readUInt16BE(pos);
+      pos += 2;
+      for (let j = 0; j < count; j++) {
+        const offset = stream.readUInt16BE(pos);
+        pos += 2;
+        const hash = Buffer.from(stream.subarray(pos, pos + 20));
+        pos += 20;
+        // `offset` counts bytes through this list's hash blocks back to back.
+        const within = i * sectorsPerList * SECTOR_HASH_SIZE + offset;
+        exceptions.push({
+          sector: firstSector + Math.floor(within / SECTOR_HASH_SIZE),
+          offset: within % SECTOR_HASH_SIZE,
+          hash,
+        });
+      }
+    }
+    // NONE and PURGE pad the lists out to a 4-byte boundary; the real codecs do not.
+    if (method === COMPRESSION.NONE || method === COMPRESSION.PURGE) pos = (pos + 3) & ~3;
+  }
+
+  const body = stream.subarray(pos);
+  let payload;
+  if (group.packedSize > 0) {
+    payload = decodeRvzPacking(body.subarray(0, group.packedSize), logicalSize, baseDiscOffset);
+  } else if (method === COMPRESSION.PURGE) {
+    payload = decodePurge(body, logicalSize);
+  } else {
+    if (body.length < logicalSize) {
+      throw new Error(`group ${index} decoded to ${body.length} of ${logicalSize} bytes`);
+    }
+    payload = body.subarray(0, logicalSize);
+  }
+  return { payload, exceptions };
+}
+
+// Write out one wia_raw_data_t run — the parts of the disc that are stored as
+// they appear, i.e. all of a GameCube disc and everything outside the partitions
+// on a Wii one.
+async function expandRawRun(ctx, fh, out, run, onWritten, signal) {
+  if (run.size === 0) return;
+  // The groups of a run start at the 0x8000 boundary below its offset, so the
+  // first group of the very first run (offset 0x80) really starts at 0 and its
+  // leading 0x80 bytes — which live in wia_disc_t instead — are dropped here.
+  const gridStart = run.offset - (run.offset % SECTOR_SIZE);
+  const total = run.size + (run.offset - gridStart);
+  let produced = 0;
+  for (let g = 0; g < run.numGroups && produced < total; g++) {
+    if (signal?.aborted) throw new Error('aborted');
+    const logicalSize = Math.min(ctx.chunkSize, total - produced);
+    const chunkStart = gridStart + produced;
+    const { payload } = await decodeGroup(ctx, fh, run.groupIndex + g, {
+      logicalSize,
+      exceptionLists: 0,
+      baseDiscOffset: chunkStart,
+    });
+    const from = Math.max(run.offset, chunkStart);
+    const to = Math.min(run.offset + run.size, chunkStart + logicalSize);
+    if (to > from) {
+      await out.write(payload, from - chunkStart, to - from, from);
+      onWritten(to - from);
+    }
+    produced += logicalSize;
+  }
+}
+
+// Write out one run of Wii partition data, 64 sectors at a time.
+async function expandPartitionRun(ctx, fh, out, key, run, onWritten, signal) {
+  if (run.numSectors === 0) return;
+  // Always chunk_size / 0x200000 lists, except that RVZ chunks smaller than a
+  // 64-sector group carry a single list.
+  const exceptionLists = ctx.chunkSize % WII_GROUP_SIZE === 0 ? ctx.chunkSize / WII_GROUP_SIZE : 1;
+  // A chunk covers chunk_size bytes *of disc*, which is less once the hash
+  // blocks that RVZ does not store are taken out.
+  const chunkLogicalSize = (ctx.chunkSize / SECTOR_SIZE) * SECTOR_DATA_SIZE;
+  const totalLogicalSize = run.numSectors * SECTOR_DATA_SIZE;
+  const runStart = run.firstSector * SECTOR_SIZE;
+
+  const window = Buffer.alloc(SECTORS_PER_GROUP * SECTOR_DATA_SIZE);
+  let windowFirstSector = 0;
+  let windowSectors = 0;
+  let windowExceptions = [];
+
+  const flush = async () => {
+    if (windowSectors === 0) return;
+    window.fill(0, windowSectors * SECTOR_DATA_SIZE);
+    const encrypted = rebuildWiiGroup(window, windowSectors, key, windowExceptions);
+    await out.write(encrypted, 0, encrypted.length, runStart + windowFirstSector * SECTOR_SIZE);
+    onWritten(encrypted.length);
+    windowFirstSector += windowSectors;
+    windowSectors = 0;
+    windowExceptions = [];
+  };
+
+  let produced = 0;
+  for (let g = 0; g < run.numGroups && produced < totalLogicalSize; g++) {
+    if (signal?.aborted) throw new Error('aborted');
+    const logicalSize = Math.min(chunkLogicalSize, totalLogicalSize - produced);
+    const chunkFirstSector = produced / SECTOR_DATA_SIZE;
+    const { payload, exceptions } = await decodeGroup(ctx, fh, run.groupIndex + g, {
+      logicalSize,
+      exceptionLists,
+      baseDiscOffset: runStart + produced,
+      firstSector: chunkFirstSector,
+    });
+
+    let taken = 0;
+    while (taken < logicalSize) {
+      const room = (SECTORS_PER_GROUP - windowSectors) * SECTOR_DATA_SIZE;
+      const take = Math.min(room, logicalSize - taken);
+      payload.copy(window, windowSectors * SECTOR_DATA_SIZE, taken, taken + take);
+      const sectorBase = chunkFirstSector + taken / SECTOR_DATA_SIZE;
+      for (const ex of exceptions) {
+        if (ex.sector >= sectorBase && ex.sector < sectorBase + take / SECTOR_DATA_SIZE) {
+          windowExceptions.push({ ...ex, sector: ex.sector - sectorBase + windowSectors });
+        }
+      }
+      windowSectors += take / SECTOR_DATA_SIZE;
+      taken += take;
+      if (windowSectors === SECTORS_PER_GROUP) await flush();
+    }
+    produced += logicalSize;
+  }
+  await flush();
+}
+
+// Is there room in temp for the expanded image (plus 15% headroom)?
+async function tempHasRoom(bytes) {
+  try {
+    const fs = await statfs(config.tempDir);
+    return fs.bavail * fs.bsize >= bytes * 1.15;
+  } catch { return true; }
+}
+
+/**
+ * Expand an .rvz/.wia into a plain .iso in the temp folder.
+ *
+ * Returns { path, cleanup, size } on success, { error } when the image cannot be
+ * read, or null when the file is not a WIA/RVZ at all (the caller then hashes
+ * the original as before). `onProgress(done, total)` reports written bytes.
+ */
+export async function expandRvz(filePath, { signal, onProgress } = {}) {
+  const fh = await open(filePath, 'r');
+  let ctx;
+  try {
+    ctx = await readRvzHeader(fh);
+  } catch (e) {
+    await fh.close();
+    const what = e.unsupportedCompression ? '' : 'Could not read the RVZ/WIA header: ';
+    return { error: `${what}${String(e.message).slice(0, 200)}` };
+  }
+  if (!ctx) {
+    await fh.close();
+    return null;
+  }
+  if (!(await tempHasRoom(ctx.isoSize))) {
+    await fh.close();
+    const gb = (ctx.isoSize / 1024 ** 3).toFixed(1);
+    return { error: `Not enough free space in the temp folder to expand this image (needs about ${gb} GB).` };
+  }
+
+  const dest = join(config.tempDir, `rvz-${process.pid}-${Date.now()}-${basename(filePath, extname(filePath))}.iso`);
+  const cleanup = async () => { try { await unlink(dest); } catch { /* best effort */ } };
+  const out = await open(dest, 'w');
+
+  let written = 0;
+  let lastReport = 0;
+  const onWritten = (n) => {
+    written += n;
+    if (written - lastReport >= 16 << 20) {
+      lastReport = written;
+      onProgress?.(written, ctx.isoSize);
+    }
+  };
+
+  try {
+    // Reserve the full size up front: the runs below are written at their own
+    // offsets and anything they do not cover stays zero, as on the real disc.
+    await out.truncate(ctx.isoSize);
+    // The first 0x80 bytes live in wia_disc_t, not in any group.
+    await out.write(ctx.discHead, 0, 0x80, 0);
+
+    for (const run of ctx.rawData) await expandRawRun(ctx, fh, out, run, onWritten, signal);
+
+    if (ctx.discType === DISC_TYPE_WII) {
+      for (const part of ctx.parts) {
+        for (const run of part.runs) {
+          await expandPartitionRun(ctx, fh, out, part.key, run, onWritten, signal);
+        }
+      }
+    }
+
+    onProgress?.(ctx.isoSize, ctx.isoSize);
+    const size = (await stat(dest)).size;
+    return { path: dest, cleanup, size };
+  } catch (e) {
+    await cleanup();
+    if (signal?.aborted) throw e;
+    return { error: `Could not expand the RVZ/WIA: ${String(e.message).slice(0, 200)}` };
+  } finally {
+    await out.close();
+    await fh.close();
+  }
+}

--- a/server/src/scanner.js
+++ b/server/src/scanner.js
@@ -10,7 +10,7 @@ import {
   consoleFromFolderSegments,
 } from './consoles.js';
 import { hashTarget } from './hashing/index.js';
-import { isCsoPath, expandCso } from './hashing/cso.js';
+import { isCompressedDisc, expandDiscImage } from './hashing/expand.js';
 import { listEntries, archiveType } from './hashing/archive.js';
 import { config } from './config.js';
 import {
@@ -270,9 +270,9 @@ export class Scanner {
     let targetExt = ext;
     let localCopy = true;
     let cleanup = null;
-    if (isCsoPath(filePath)) {
+    if (isCompressedDisc(filePath)) {
       const onPhase = (p, done, total) => this.emit('phase', { file: phaseFile, phase: p, done, total });
-      const expanded = await expandCso(filePath, {
+      const expanded = await expandDiscImage(filePath, filePath, {
         signal: this.signal,
         onProgress: (done, total) => onPhase('extracting', done, total),
       });

--- a/server/test/rvz.test.js
+++ b/server/test/rvz.test.js
@@ -1,0 +1,463 @@
+// Tests for WIA/RVZ expansion (server/src/hashing/rvz.js).
+//
+// The format stores a disc as compressed chunks, with Wii partitions kept
+// decrypted and hash-stripped and unused areas replaced by the seed of the
+// generator that produced their padding. These tests build a reference ISO,
+// pack it into a WIA/RVZ by hand, expand it again and require the result to be
+// byte-identical — that equality is what makes the RetroAchievements hash
+// RAHasher then produces trustworthy.
+//
+// The packer and the Wii hash-tree builder below are written independently of
+// the ones in rvz.js (straight-line, no streaming) so that a transcription slip
+// in either shows up as a mismatch rather than cancelling out.
+//
+// rvz.js writes the expanded image into config.tempDir, so RA_DATA_DIR points at
+// a throwaway directory BEFORE the import.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash, createCipheriv } from 'node:crypto';
+import { zstdCompressSync } from 'node:zlib';
+
+const tempDataDir = mkdtempSync(join(tmpdir(), 'ra-checker-rvz-'));
+process.env.RA_DATA_DIR = tempDataDir;
+
+let rvz;
+before(async () => { rvz = await import('../src/hashing/rvz.js'); });
+after(() => { try { rmSync(tempDataDir, { recursive: true, force: true }); } catch { /* windows file locks */ } });
+
+const NONE = 0;
+const ZSTD = 5;
+const SECTOR = 0x8000;
+const SDATA = 0x7c00;
+const SHASH = 0x400;
+
+const sha1 = (b) => createHash('sha1').update(b).digest();
+
+// Deterministic filler that does not compress to nothing.
+function noise(size, seed = 1) {
+  const buf = Buffer.alloc(size);
+  let s = seed >>> 0;
+  for (let i = 0; i < size; i++) {
+    s = (Math.imul(s, 1103515245) + 12345) >>> 0;
+    buf[i] = (s >>> 16) & 0xff;
+  }
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// The lagged Fibonacci generator, written the way Dolphin does it: the output
+// transform is applied once to the whole state (it is XOR-linear, so it commutes
+// with the stepping) and the bytes then fall out in big-endian order. rvz.js
+// applies the same transform per byte instead, so the two agreeing is a real
+// cross-check of the "shift by 18, not 16" quirk.
+function junkBytes(seed, skip, count) {
+  const state = new Uint32Array(521);
+  for (let i = 0; i < 17; i++) state[i] = seed.readUInt32BE(i * 4);
+  for (let i = 17; i < 521; i++) {
+    state[i] = (((state[i - 17] << 23) >>> 0) ^ (state[i - 16] >>> 9) ^ state[i - 1]) >>> 0;
+  }
+  const step = () => {
+    for (let i = 0; i < 32; i++) state[i] = (state[i] ^ state[i + 521 - 32]) >>> 0;
+    for (let i = 32; i < 521; i++) state[i] = (state[i] ^ state[i - 32]) >>> 0;
+  };
+  for (let i = 0; i < 4; i++) step();
+
+  const page = Buffer.alloc(521 * 4);
+  const render = () => {
+    for (let i = 0; i < 521; i++) {
+      const x = state[i];
+      page.writeUInt32BE(((x & 0xff00ffff) | ((x >>> 2) & 0x00ff0000)) >>> 0, i * 4);
+    }
+  };
+  render();
+
+  let pos = 0;
+  const consume = (n, target) => {
+    let done = 0;
+    while (done < n) {
+      if (pos === page.length) { step(); render(); pos = 0; }
+      const take = Math.min(page.length - pos, n - done);
+      if (target) page.copy(target, done, pos, pos + take);
+      done += take;
+      pos += take;
+    }
+  };
+
+  const out = Buffer.alloc(count);
+  consume(skip, null);
+  consume(count, out);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// WIA/RVZ writer. `jobs` are the group payloads in group-table order.
+//
+//   { zero: true }                                  a group of nothing but zeroes
+//   { body, packedSize?, exceptionLists?, raw? }     everything else
+//
+// `raw` stores the group without compressing it, which RVZ marks with a cleared
+// top bit in data_size.
+function buildImage({
+  isRvz = true, discType = 1, compression = NONE, chunkSize,
+  isoSize, discHead, rawRuns = [], partitions = [], jobs,
+}) {
+  const encodeJob = (job) => {
+    if (job.zero) return { stored: Buffer.alloc(0), dataSize: 0, packedSize: 0 };
+    const pieces = [];
+    for (const list of job.exceptionLists ?? []) {
+      const buf = Buffer.alloc(2 + list.length * 22);
+      buf.writeUInt16BE(list.length, 0);
+      list.forEach((ex, i) => {
+        buf.writeUInt16BE(ex.offset, 2 + i * 22);
+        ex.hash.copy(buf, 4 + i * 22);
+      });
+      pieces.push(buf);
+    }
+    let head = Buffer.concat(pieces);
+    const method = job.raw ? NONE : compression;
+    if (job.exceptionLists && method === NONE && head.length % 4 !== 0) {
+      head = Buffer.concat([head, Buffer.alloc(4 - (head.length % 4))]);
+    }
+    const plain = Buffer.concat([head, job.body]);
+    const stored = method === ZSTD ? zstdCompressSync(plain) : plain;
+    const flag = isRvz && method !== NONE ? 0x80000000 : 0;
+    return { stored, dataSize: (stored.length | flag) >>> 0, packedSize: job.packedSize ?? 0 };
+  };
+
+  const encoded = jobs.map(encodeJob);
+  const groupEntrySize = isRvz ? 12 : 8;
+
+  const partTable = Buffer.alloc(partitions.length * 0x30);
+  partitions.forEach((p, i) => {
+    p.key.copy(partTable, i * 0x30);
+    p.runs.forEach((r, j) => {
+      const o = i * 0x30 + 16 + j * 16;
+      partTable.writeUInt32BE(r.firstSector, o);
+      partTable.writeUInt32BE(r.numSectors, o + 4);
+      partTable.writeUInt32BE(r.groupIndex, o + 8);
+      partTable.writeUInt32BE(r.numGroups, o + 12);
+    });
+  });
+
+  const rawTable = Buffer.alloc(rawRuns.length * 0x18);
+  rawRuns.forEach((r, i) => {
+    const o = i * 0x18;
+    rawTable.writeBigUInt64BE(BigInt(r.offset), o);
+    rawTable.writeBigUInt64BE(BigInt(r.size), o + 8);
+    rawTable.writeUInt32BE(r.groupIndex, o + 16);
+    rawTable.writeUInt32BE(r.numGroups, o + 20);
+  });
+
+  // Tables carry the disc's compression; group offsets are stored divided by 4,
+  // so every blob has to start on a 4-byte boundary.
+  const packTable = (buf) => (compression === ZSTD ? zstdCompressSync(buf) : buf);
+  const packedRaw = packTable(rawTable);
+
+  const parts = [];
+  let cursor = 0x48 + 0xdc;
+  const place = (buf) => {
+    const pad = (4 - (cursor % 4)) % 4;
+    if (pad) { parts.push(Buffer.alloc(pad)); cursor += pad; }
+    const at = cursor;
+    parts.push(buf);
+    cursor += buf.length;
+    return at;
+  };
+
+  const partOffset = place(partTable);
+  const rawOffset = place(packedRaw);
+  // The group table needs the blob offsets, which need the table's own size, so
+  // it is laid out first with a placeholder and filled in afterwards.
+  const groupTable = Buffer.alloc(encoded.length * groupEntrySize);
+  const groupTableOffset = place(Buffer.alloc(groupTable.length + 1024));
+  const blobStart = [];
+  for (const e of encoded) blobStart.push(e.stored.length ? place(e.stored) : 0);
+
+  encoded.forEach((e, i) => {
+    const o = i * groupEntrySize;
+    groupTable.writeUInt32BE(blobStart[i] / 4, o);
+    groupTable.writeUInt32BE(e.dataSize, o + 4);
+    if (groupEntrySize >= 12) groupTable.writeUInt32BE(e.packedSize, o + 8);
+  });
+  const packedGroups = packTable(groupTable);
+  assert.ok(packedGroups.length <= groupTable.length + 1024, 'group table outgrew its reserved space');
+
+  const disc = Buffer.alloc(0xdc);
+  disc.writeUInt32BE(discType, 0x00);
+  disc.writeUInt32BE(compression, 0x04);
+  disc.writeUInt32BE(chunkSize, 0x0c);
+  discHead.copy(disc, 0x10);
+  disc.writeUInt32BE(partitions.length, 0x90);
+  disc.writeUInt32BE(0x30, 0x94);
+  disc.writeBigUInt64BE(BigInt(partOffset), 0x98);
+  disc.writeUInt32BE(rawRuns.length, 0xb4);
+  disc.writeBigUInt64BE(BigInt(rawOffset), 0xb8);
+  disc.writeUInt32BE(packedRaw.length, 0xc0);
+  disc.writeUInt32BE(encoded.length, 0xc4);
+  disc.writeBigUInt64BE(BigInt(groupTableOffset), 0xc8);
+  disc.writeUInt32BE(packedGroups.length, 0xd0);
+
+  const head = Buffer.alloc(0x48);
+  head.write(isRvz ? 'RVZ\x01' : 'WIA\x01', 0, 'latin1');
+  head.writeUInt32BE(1, 0x04);
+  head.writeUInt32BE(1, 0x08);
+  head.writeUInt32BE(0xdc, 0x0c);
+  head.writeBigUInt64BE(BigInt(isoSize), 0x24);
+
+  const body = Buffer.concat(parts);
+  const file = Buffer.concat([head, disc, body]);
+  // Splice the (possibly compressed) group table over its placeholder.
+  packedGroups.copy(file, groupTableOffset);
+  head.writeBigUInt64BE(BigInt(file.length), 0x2c);
+  head.copy(file, 0);
+  return file;
+}
+
+// Encode a group as an RVZ-packed stream of literal and padding runs.
+// `runs` = [{ junk: bool, size, seed? , data? }].
+function packRuns(runs) {
+  const pieces = [];
+  for (const run of runs) {
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE((run.size | (run.junk ? 0x80000000 : 0)) >>> 0, 0);
+    pieces.push(header, run.junk ? run.seed : run.data);
+  }
+  return Buffer.concat(pieces);
+}
+
+// ---------------------------------------------------------------------------
+// The encrypted, hashed on-disc form of a run of Wii partition sectors, built
+// the obvious way: hash every sector, then every subgroup, then every group.
+function encryptPartition(plain, sectorCount, key, exceptions) {
+  const nominal = Math.ceil(sectorCount / 64) * 64;
+  const blocks = [];
+  for (let s = 0; s < nominal; s++) {
+    const block = Buffer.alloc(SHASH);
+    for (let i = 0; i < 31; i++) {
+      const at = s * SDATA + i * 0x400;
+      const chunk = s < sectorCount ? plain.subarray(at, at + 0x400) : Buffer.alloc(0x400);
+      sha1(chunk).copy(block, i * 20);
+    }
+    blocks.push(block);
+  }
+  for (let sub = 0; sub < nominal / 8; sub++) {
+    const h1 = Buffer.alloc(160);
+    for (let i = 0; i < 8; i++) sha1(blocks[sub * 8 + i].subarray(0, 0x26c)).copy(h1, i * 20);
+    for (let i = 0; i < 8; i++) h1.copy(blocks[sub * 8 + i], 0x280);
+  }
+  for (let grp = 0; grp < nominal / 64; grp++) {
+    const h2 = Buffer.alloc(160);
+    for (let sg = 0; sg < 8; sg++) {
+      sha1(blocks[grp * 64 + sg * 8].subarray(0x280, 0x320)).copy(h2, sg * 20);
+    }
+    for (let i = 0; i < 64; i++) h2.copy(blocks[grp * 64 + i], 0x340);
+  }
+  for (const ex of exceptions) ex.hash.copy(blocks[ex.sector], ex.offset);
+
+  const out = Buffer.alloc(sectorCount * SECTOR);
+  const zeroIv = Buffer.alloc(16);
+  for (let s = 0; s < sectorCount; s++) {
+    const hc = createCipheriv('aes-128-cbc', key, zeroIv).setAutoPadding(false);
+    const encHash = Buffer.concat([hc.update(blocks[s]), hc.final()]);
+    const dc = createCipheriv('aes-128-cbc', key, encHash.subarray(0x3d0, 0x3e0)).setAutoPadding(false);
+    const encData = Buffer.concat([dc.update(plain.subarray(s * SDATA, (s + 1) * SDATA)), dc.final()]);
+    encHash.copy(out, s * SECTOR);
+    encData.copy(out, s * SECTOR + SHASH);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+let fixtureNo = 0;
+async function roundTrip(file, expectedIso) {
+  const path = join(tempDataDir, `fixture-${fixtureNo++}.rvz`);
+  writeFileSync(path, file);
+  const result = await rvz.expandRvz(path);
+  assert.equal(result?.error, undefined, `expandRvz failed: ${result?.error}`);
+  try {
+    const got = readFileSync(result.path);
+    assert.equal(got.length, expectedIso.length, 'expanded image has the wrong length');
+    if (!got.equals(expectedIso)) {
+      const at = got.findIndex((b, i) => b !== expectedIso[i]);
+      assert.fail(`expanded image differs from the reference at 0x${at.toString(16)}`);
+    }
+  } finally {
+    await result.cleanup();
+  }
+}
+
+// A GameCube-shaped disc: everything is raw data, no partitions. 4 chunks of
+// 128 KiB — the size Dolphin defaults to — covering a group of real content, a
+// group of zeroes, a group that is nothing but padding, and a group whose
+// padding starts part-way through a sector.
+function gameCubeFixture(compression, { isRvz = true, chunkSize = 0x20000 } = {}) {
+  const isoSize = chunkSize * 4;
+  const discHead = noise(0x80, 7);
+  discHead.writeUInt32BE(0xc2339f3d, 0x1c); // the GameCube magic word
+
+  const seedA = noise(68, 11);
+  const seedB = noise(68, 12);
+  const iso = Buffer.alloc(isoSize);
+  discHead.copy(iso, 0);
+  noise(chunkSize - 0x80, 2).copy(iso, 0x80);
+  // chunk 1 stays zero
+  junkBytes(seedA, 0, chunkSize).copy(iso, chunkSize * 2);
+  const literal = noise(0x1000, 3);
+  literal.copy(iso, chunkSize * 3);
+  // 0x1000 into the chunk, so the generator has to skip that far into its sector
+  junkBytes(seedB, 0x1000, 0x1000).copy(iso, chunkSize * 3 + 0x1000);
+  noise(chunkSize - 0x2000, 4).copy(iso, chunkSize * 3 + 0x2000);
+
+  const tail = noise(chunkSize - 0x2000, 4);
+  const jobs = [
+    { body: iso.subarray(0, chunkSize) },
+    { zero: true },
+    ...(isRvz
+      ? [{ body: packRuns([{ junk: true, size: chunkSize, seed: seedA }]), packedSize: 4 + 68 }]
+      : [{ body: iso.subarray(chunkSize * 2, chunkSize * 3) }]),
+    ...(isRvz
+      ? [{
+          body: packRuns([
+            { size: 0x1000, data: literal },
+            { junk: true, size: 0x1000, seed: seedB },
+            { size: chunkSize - 0x2000, data: tail },
+          ]),
+          packedSize: 4 * 3 + 0x1000 + 68 + (chunkSize - 0x2000),
+          raw: true, // stored uncompressed even on a compressed disc
+        }]
+      : [{ body: iso.subarray(chunkSize * 3) }]),
+  ];
+
+  const file = buildImage({
+    isRvz, discType: 1, compression, chunkSize, isoSize, discHead,
+    rawRuns: [{ offset: 0x80, size: isoSize - 0x80, groupIndex: 0, numGroups: 4 }],
+    jobs,
+  });
+  return { file, iso };
+}
+
+test('RVZ: a GameCube disc round-trips byte for byte (uncompressed)', async () => {
+  const { file, iso } = gameCubeFixture(NONE);
+  await roundTrip(file, iso);
+});
+
+test('RVZ: a GameCube disc round-trips byte for byte (Zstandard)', async () => {
+  const { file, iso } = gameCubeFixture(ZSTD);
+  await roundTrip(file, iso);
+});
+
+test('WIA: a GameCube disc round-trips byte for byte', async () => {
+  // WIA has no RVZ packing and its chunks are multiples of 2 MiB.
+  const { file, iso } = gameCubeFixture(ZSTD, { isRvz: false, chunkSize: 0x200000 });
+  await roundTrip(file, iso);
+});
+
+// A Wii-shaped disc: raw data on either side of one partition of 70 sectors,
+// which is 64 + 6 — so the last group is partial and its hash tree still has to
+// cover all 64 nominal sectors.
+const PARTITION_FIRST_SECTOR = 4;
+const PARTITION_SECTORS = 70;
+
+function wiiFixture(chunkSize) {
+  const partOffset = PARTITION_FIRST_SECTOR * SECTOR;
+  const partBytes = PARTITION_SECTORS * SECTOR;
+  const tailOffset = partOffset + partBytes;
+  const isoSize = tailOffset + SECTOR;
+
+  const discHead = noise(0x80, 21);
+  discHead.writeUInt32BE(0x5d1c9ea3, 0x18); // the Wii magic word
+  const key = noise(16, 22);
+  const plain = noise(PARTITION_SECTORS * SDATA, 23);
+  // Two sectors whose stored hashes do not match the tree: one in the full first
+  // group, one in the short trailing group.
+  const exceptions = [
+    { sector: 3, offset: 0x14, hash: noise(20, 24) },
+    { sector: 67, offset: 0x2a0, hash: noise(20, 25) },
+  ];
+
+  const iso = Buffer.alloc(isoSize);
+  discHead.copy(iso, 0);
+  noise(partOffset - 0x80, 26).copy(iso, 0x80);
+  encryptPartition(plain, PARTITION_SECTORS, key, exceptions).copy(iso, partOffset);
+  noise(SECTOR, 27).copy(iso, tailOffset);
+
+  // Raw runs: everything before the partition, and the sector after it.
+  const headRun = { offset: 0x80, size: partOffset - 0x80, groupIndex: 0, numGroups: 1 };
+  const jobs = [{ body: iso.subarray(0, partOffset) }];
+
+  const tailRun = { offset: tailOffset, size: SECTOR, groupIndex: 1, numGroups: 1 };
+  jobs.push({ body: iso.subarray(tailOffset) });
+
+  // Partition chunks. One exception list per 2 MiB group, each covering 64
+  // sectors — or the whole chunk when a chunk is smaller than that.
+  const sectorsPerChunk = chunkSize / SECTOR;
+  const listsPerChunk = chunkSize % 0x200000 === 0 ? chunkSize / 0x200000 : 1;
+  const sectorsPerList = Math.min(64, sectorsPerChunk);
+  const numGroups = Math.ceil(PARTITION_SECTORS / sectorsPerChunk);
+  for (let g = 0; g < numGroups; g++) {
+    const first = g * sectorsPerChunk;
+    const count = Math.min(sectorsPerChunk, PARTITION_SECTORS - first);
+    const lists = [];
+    for (let l = 0; l < listsPerChunk; l++) {
+      lists.push(
+        exceptions
+          .filter((ex) => ex.sector >= first + l * sectorsPerList && ex.sector < first + (l + 1) * sectorsPerList)
+          .map((ex) => ({ offset: (ex.sector - first - l * sectorsPerList) * SHASH + ex.offset, hash: ex.hash }))
+      );
+    }
+    jobs.push({
+      body: plain.subarray(first * SDATA, (first + count) * SDATA),
+      exceptionLists: lists,
+    });
+  }
+
+  const file = buildImage({
+    isRvz: true, discType: 2, compression: ZSTD, chunkSize, isoSize, discHead,
+    rawRuns: [headRun, tailRun],
+    partitions: [{
+      key,
+      runs: [
+        { firstSector: PARTITION_FIRST_SECTOR, numSectors: PARTITION_SECTORS, groupIndex: 2, numGroups },
+        { firstSector: 0, numSectors: 0, groupIndex: 0, numGroups: 0 },
+      ],
+    }],
+    jobs,
+  });
+  return { file, iso };
+}
+
+test('RVZ: a Wii partition is re-hashed and re-encrypted (chunks below 2 MiB)', async () => {
+  const { file, iso } = wiiFixture(0x20000);
+  await roundTrip(file, iso);
+});
+
+test('RVZ: a Wii partition is re-hashed and re-encrypted (chunk with two exception lists)', async () => {
+  const { file, iso } = wiiFixture(0x400000);
+  await roundTrip(file, iso);
+});
+
+test('expandRvz ignores files that are not WIA/RVZ', async () => {
+  const path = join(tempDataDir, 'not-an-image.rvz');
+  writeFileSync(path, noise(4096, 31));
+  assert.equal(await rvz.expandRvz(path), null);
+});
+
+test('expandRvz names the compression it cannot read', async () => {
+  const { file } = gameCubeFixture(NONE);
+  file.writeUInt32BE(4, 0x48 + 0x04); // claim LZMA2
+  const path = join(tempDataDir, 'lzma2.rvz');
+  writeFileSync(path, file);
+  const result = await rvz.expandRvz(path);
+  assert.match(result.error, /LZMA2/);
+  assert.match(result.error, /Zstandard/);
+});
+
+test('isRvzPath covers both extensions and nothing else', () => {
+  assert.equal(rvz.isRvzPath('C:/roms/Game.RVZ'), true);
+  assert.equal(rvz.isRvzPath('/roms/Game.wia'), true);
+  assert.equal(rvz.isRvzPath('/roms/Game.iso'), false);
+  assert.equal(rvz.isRvzPath('/roms/Game.cso'), false);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker-web",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version + changelog. The footer version
 // chip opens a modal rendering CHANGELOG; package.json is kept in sync manually.
-export const APP_VERSION = '0.14.1';
+export const APP_VERSION = '0.15.0';
 
 // GitHub repository — linked from the header (GitHub icon in the "More" menu).
 export const REPO_URL = 'https://github.com/x3kim/RAChecker';
@@ -15,6 +15,15 @@ export interface Release { version: string; date: string; title?: { de: string; 
 
 // Newest first. Dates are ISO (YYYY-MM-DD).
 export const CHANGELOG: Release[] = [
+  {
+    version: '0.15.0',
+    date: '2026-08-18',
+    title: { de: 'GameCube- und Wii-Images (RVZ)', en: 'GameCube and Wii images (RVZ)' },
+    changes: [
+      { type: 'feature', de: 'Die komprimierten GameCube- und Wii-Images von Dolphin (.rvz, .wia) werden jetzt gehasht. RAHasher kann sie nicht öffnen, deshalb blieben solche Dateien bisher ohne Hash liegen — RAChecker packt sie dafür kurz in eine echte ISO aus und räumt sie danach wieder weg. Bei Wii-Discs werden die Partitionen dabei neu gehasht und verschlüsselt, damit das Ergebnis dem Original-Dump Byte für Byte entspricht. Mit bzip2, LZMA oder LZMA2 komprimierte Images meldet RAChecker als nicht unterstützt — in Dolphin mit Zstandard neu komprimieren, der Voreinstellung.', en: 'The compressed GameCube and Wii images Dolphin writes (.rvz, .wia) are hashed now. RAHasher cannot open them, so those files were left without a hash — RAChecker expands them into a real ISO for the moment it takes to hash, then removes it again. For Wii discs the partitions are re-hashed and re-encrypted along the way, so the result matches the original dump byte for byte. Images compressed with bzip2, LZMA or LZMA2 are reported as unsupported — re-compress them in Dolphin with Zstandard, its default.' },
+      { type: 'fix', de: 'Die Endung .wia war keinem System zugeordnet und wurde beim Scannen übergangen. Sie zählt jetzt wie .rvz zu GameCube und Wii.', en: 'The .wia extension was not assigned to any system and was passed over while scanning. It now counts towards GameCube and Wii just like .rvz.' },
+    ],
+  },
   {
     version: '0.14.1',
     date: '2026-08-18',


### PR DESCRIPTION
Drumcan2077 reported that RVZ scans came back without a hash. RAHasher only
reads raw disc images, so every `.rvz` fell through with nothing to look up —
and `.wia` was not even on any console's extension list, so those files were
skipped outright.

Both are fixed here: an `.rvz`/`.wia` is expanded into a plain `.iso` in the
temp folder for the moment it takes to hash and removed again, the same way
`.cso`/`.zso` already were.

## What the reader does

`server/src/hashing/rvz.js` implements the format from Dolphin's
[`docs/WiaAndRvz.md`](https://github.com/dolphin-emu/dolphin/blob/master/docs/WiaAndRvz.md):

- **Raw data runs** — including the 0x8000 rounding that makes the first run
  start at disc offset 0 although it declares 0x80.
- **RVZ packing** — the padding Nintendo's mastering wrote into unused areas is
  stored only as the 68-byte seed of the lagged Fibonacci generator that made
  it, so it has to be replayed byte for byte.
- **Wii partitions** — the format keeps them decrypted and hash-stripped. The
  H0/H1/H2 tree is recomputed, the recorded hash exceptions applied, and every
  sector re-encrypted with the partition's title key.

It runs one 64-sector group at a time, so a 4.7 GB Wii disc never has to fit in
a Buffer.

## Compression

Zstandard is what Dolphin defaults to and what the report was about; Node has a
decoder built in, so **this PR adds no dependency**. `none` and WIA's `purge`
come along for free. bzip2, LZMA and LZMA2 are refused with a message naming the
codec and pointing at Dolphin's *Convert File…* dialog — each would need a
decoder of its own, and none of them is a default.

## Verification

1. **Round-trip tests** (`server/test/rvz.test.js`, 8 new tests). The packer and
   the Wii hash-tree builder in the test are written independently of the ones
   in `rvz.js`, so a transcription slip in either shows up rather than
   cancelling out. Covered: GameCube uncompressed and Zstandard, WIA, a Wii
   partition with hash exceptions in both a full group and a short trailing one,
   chunk sizes above and below 2 MiB, junk runs starting mid-sector.
2. **Differential check against [DesertDoggy/RVZ-reader](https://github.com/DesertDoggy/RVZ-reader)**,
   which its author verified byte-exact against real GameCube and Wii dumps. It
   produces identical output on four of the five fixtures.

   The fifth is a bug on its side, worth passing back: it splits a chunk's
   exception lists proportionally (`sectorsInChunk / numLists`), but the format
   keeps one list per 2 MiB "even for a `wia_group_t` which contains less data
   than normal due to it being at the end of a partition". In a run's last,
   short chunk its offsets therefore land on the wrong sector — here, an
   exception meant for sector 67 was written to sector 38.
3. **End to end with the real RAHasher.** A synthetic GameCube image hashes
   identically whether RAHasher is handed the `.iso` or `hashTarget` is handed
   the `.rvz`.

Full suite: 114/114 green, `tsc` clean.

Thanks to @DesertDoggy — the reference converter is what made checking this
possible without a real dump to hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable reliable hashing of Dolphin-compressed GameCube and Wii disc images by expanding supported containers to raw ISOs before scanning.

New Features:
- Add support for expanding and hashing Dolphin `.rvz` and `.wia` GameCube and Wii images, including Zstandard, uncompressed, purge, packing, and Wii partition reconstruction.

Bug Fixes:
- Recognize `.wia` files for GameCube and Wii scanning instead of skipping them.
- Report unsupported bzip2, LZMA, and LZMA2 image compression with guidance to re-compress using Zstandard.

Enhancements:
- Unify compressed disc expansion for existing `.cso`/`.zso` images and new Dolphin containers before RAHasher processing.

Build:
- Bump the application and package versions to 0.15.0.

Documentation:
- Document temporary expansion and supported compression formats for compressed disc images.

Tests:
- Add independent round-trip coverage for GameCube, WIA, RVZ packing, Zstandard compression, and Wii partition hash reconstruction.