### PR TITLE
Every WIA/RVZ compression method, GCZ images, and an rvz-info diagnostic (desktop 0.16.0)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -253,11 +253,18 @@ Der automatische Download geht nur unter Windows. Unter Linux/macOS RAHasher sel
 
 **Android** braucht keinen RAHasher — die Disc-Regeln sind direkt in der App umgesetzt.
 
-**Komprimierte Container, die RAHasher nicht öffnen kann** — `.cso`/`.zso` (PSP, PS2) und
-Dolphins `.rvz`/`.wia` (GameCube, Wii) — werden für die Dauer des Hashens in eine echte `.iso`
-im Temp-Ordner ausgepackt und danach wieder entfernt. Der Hash ist derselbe wie beim
-unkomprimierten Image. `.rvz`/`.wia` mit bzip2, LZMA oder LZMA2 werden als nicht unterstützt
-gemeldet — in Dolphin mit **Zstandard** neu komprimieren, der Voreinstellung.
+**Komprimierte Container, die RAHasher nicht öffnen kann** — `.cso`/`.zso` (PSP, PS2) sowie
+Dolphins `.rvz`/`.wia` und das ältere `.gcz` (GameCube, Wii) — werden für die Dauer des
+Hashens in eine echte `.iso` im Temp-Ordner ausgepackt und danach wieder entfernt. Der Hash
+ist derselbe wie beim unkomprimierten Image. Alle Kompressionsverfahren, die WIA/RVZ kennt,
+werden gelesen: none, Purge, bzip2, LZMA, LZMA2 und Zstandard.
+
+`.wbfs` wird **noch nicht** unterstützt. RAHasher liest den Container-Header, als wäre er die
+Disc, und weist die Datei ab — solche Images können vorerst gar nicht zugeordnet werden.
+
+Was in einem Disc-Image wirklich steckt — Kompression, Chunk-Größe, Disc-Typ — zeigt
+`npm run rvz:info -- "D:\ROMs\GameCube"`. Das Script liest nur die ersten 92 Byte pro Datei
+und ist damit auch über eine Netzwerkfreigabe schnell.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -252,10 +252,17 @@ The automatic download is Windows-only. On Linux/macOS, build RAHasher yourself 
 **Android** doesn't need RAHasher — the disc rules are implemented natively in the app.
 
 **Compressed containers RAHasher cannot open** — `.cso`/`.zso` (PSP, PS2) and Dolphin's
-`.rvz`/`.wia` (GameCube, Wii) — are expanded into a plain `.iso` in the temp folder for the
-moment it takes to hash, then removed again. The hash is the one the raw image produces.
-`.rvz`/`.wia` written with bzip2, LZMA or LZMA2 are reported as unsupported; re-compress them
-in Dolphin with **Zstandard**, which is what it defaults to.
+`.rvz`/`.wia` and older `.gcz` (GameCube, Wii) — are expanded into a plain `.iso` in the temp
+folder for the moment it takes to hash, then removed again. The hash is the one the raw image
+produces. Every compression method WIA/RVZ defines is read: none, Purge, bzip2, LZMA, LZMA2
+and Zstandard.
+
+`.wbfs` is **not** supported yet. RAHasher reads the container header as if it were the disc
+and rejects the file, so those images cannot be matched at all for now.
+
+To see what a disc image actually holds — its compression, chunk size and disc type —
+run `npm run rvz:info -- "D:\ROMs\GameCube"`. It reads only the first 92 bytes of each file,
+so it is quick even over a network share.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,10 +16,9 @@ Tab **Hash-DB** → **Synchronisieren** (oder **Komplett neu** für ein vollstä
 Nur nötig für Disc-Systeme (PS1/PS2/PSP/Saturn/Dreamcast/…) und `.chd`.
 Tab **Einstellungen** → **RAHasher herunterladen.** Cartridge-Systeme funktionieren ohne.
 
-Komprimierte Container, die RAHasher nicht öffnet — `.cso`/`.zso` und Dolphins `.rvz`/`.wia` —
-packt RAChecker zum Hashen kurz in eine echte `.iso` aus und räumt sie danach wieder weg.
-`.rvz`/`.wia` mit bzip2, LZMA oder LZMA2 werden als nicht unterstützt gemeldet; in Dolphin mit
-**Zstandard** neu komprimieren (Voreinstellung).
+Komprimierte Container, die RAHasher nicht öffnet — `.cso`/`.zso` sowie Dolphins `.rvz`/`.wia`
+und `.gcz` — packt RAChecker zum Hashen kurz in eine echte `.iso` aus und räumt sie danach
+wieder weg; alle Kompressionsverfahren von WIA/RVZ werden gelesen. `.wbfs` geht noch nicht.
 
 ## 3. Bibliothek scannen
 Tab **Scannen**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "description": "RetroAchievements ROM Compatibility Checker — scan your ROM library and find which games can earn achievements.",
@@ -24,6 +24,7 @@
     "serve": "npm run build && npm run start",
     "test": "node --no-warnings --test server/test/*.test.js packages/core/test/*.test.js",
     "icon": "node scripts/make-icon.mjs",
+    "rvz:info": "node scripts/rvz-info.mjs",
     "app:dev": "npm run build && electron .",
     "app:dist": "npm run build && electron-builder --win",
     "app:dir": "npm run build && electron-builder --win --dir",

--- a/scripts/rvz-info.mjs
+++ b/scripts/rvz-info.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Report what is inside every .rvz/.wia below a path: which disc it holds, which
+// compression it uses and how big its chunks are.
+//
+//   npm run rvz:info -- "D:\\ROMs\\GameCube"
+//   node scripts/rvz-info.mjs "\\\\NAS\\roms"
+//
+// Useful when someone reports that a disc image will not hash: the compression
+// method is the first thing worth knowing, and it is not visible anywhere else
+// without opening the file in Dolphin.
+//
+// Only the first 0x5c bytes of each file are read, so this is fast even over a
+// network share and even for a folder of 40 GB images.
+import { readdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
+import { join, extname, resolve } from 'node:path';
+
+const COMPRESSION = ['none', 'Purge', 'bzip2', 'LZMA', 'LZMA2', 'Zstandard'];
+const DISC_TYPE = ['(none)', 'GameCube', 'Wii'];
+// Everything RAChecker's expander implements. Anything outside this list is from
+// a newer Dolphin than the format documentation this was written against.
+const SUPPORTED = new Set([0, 1, 2, 3, 4, 5]);
+
+const HEAD = 0x5c; // file header (0x48) + enough of wia_disc_t to reach chunk_size
+
+function* walk(path) {
+  let entries;
+  try {
+    entries = readdirSync(path, { withFileTypes: true });
+  } catch (e) {
+    console.error(`cannot read ${path}: ${e.message}`);
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(path, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+function describe(file) {
+  const buf = Buffer.alloc(HEAD);
+  const fd = openSync(file, 'r');
+  let read;
+  try { read = readSync(fd, buf, 0, HEAD, 0); } finally { closeSync(fd); }
+  if (read < HEAD) return { error: 'file is too short to be a WIA/RVZ' };
+
+  const magic = buf.toString('latin1', 0, 4);
+  if (magic !== 'WIA\x01' && magic !== 'RVZ\x01') return { error: 'not a WIA/RVZ (wrong magic)' };
+
+  return {
+    format: magic.slice(0, 3),
+    isoSize: Number(buf.readBigUInt64BE(0x24)),
+    discType: buf.readUInt32BE(0x48),
+    compression: buf.readUInt32BE(0x4c),
+    chunkSize: buf.readUInt32BE(0x54),
+  };
+}
+
+const root = resolve(process.argv[2] ?? '.');
+let files;
+try {
+  files = statSync(root).isDirectory() ? [...walk(root)] : [root];
+} catch (e) {
+  console.error(`cannot read ${root}: ${e.message}`);
+  process.exit(1);
+}
+
+const images = files.filter((f) => ['.rvz', '.wia'].includes(extname(f).toLowerCase()));
+if (images.length === 0) {
+  console.log(`No .rvz or .wia files under ${root}`);
+  process.exit(0);
+}
+
+const size = (n) => (n >= 1024 ** 3 ? `${(n / 1024 ** 3).toFixed(2)} GB` : `${Math.round(n / 1024 ** 2)} MB`);
+const byCompression = new Map();
+let unreadable = 0;
+
+console.log(`${'format'.padEnd(7)}${'compression'.padEnd(12)}${'chunk'.padEnd(9)}${'disc'.padEnd(10)}${'size'.padEnd(10)}file`);
+for (const file of images) {
+  let info;
+  try { info = describe(file); } catch (e) { info = { error: e.message }; }
+  if (info.error) {
+    console.log(`${'?'.padEnd(7)}${info.error.padEnd(41)}${file}`);
+    unreadable++;
+    continue;
+  }
+  const name = COMPRESSION[info.compression] ?? `type ${info.compression}`;
+  byCompression.set(name, (byCompression.get(name) ?? 0) + 1);
+  console.log(
+    info.format.padEnd(7) +
+    name.padEnd(12) +
+    `${info.chunkSize / 1024} KiB`.padEnd(9) +
+    (DISC_TYPE[info.discType] ?? `type ${info.discType}`).padEnd(10) +
+    size(info.isoSize).padEnd(10) +
+    file
+  );
+}
+
+console.log(`\n${images.length} image(s):`);
+for (const [name, count] of [...byCompression].sort((a, b) => b[1] - a[1])) {
+  const index = COMPRESSION.indexOf(name);
+  const ok = index >= 0 && SUPPORTED.has(index);
+  console.log(`  ${String(count).padStart(5)}  ${name}${ok ? '' : '  <- RAChecker cannot read this; please report it'}`);
+}
+if (unreadable) console.log(`  ${String(unreadable).padStart(5)}  unreadable`);

--- a/server/src/hashing/bzip2.js
+++ b/server/src/hashing/bzip2.js
@@ -1,0 +1,287 @@
+// bzip2 decompression.
+//
+// Needed because WIA/RVZ can compress its groups with bzip2 and Node ships no
+// decoder for it (deflate, brotli and Zstandard only). Pulling in a package for
+// this would be a runtime dependency for a codec that is not even Dolphin's
+// default, so it is decoded here — the same call the LZ4 decoder in cso.js makes.
+//
+// A stream is "BZh" + a digit, then blocks that are *bit* aligned (not byte
+// aligned), then an end-of-stream marker:
+//
+//   'B' 'Z' 'h' '1'..'9'          the digit is the block size in 100k units
+//   0x314159265359  block         repeated
+//   0x177245385090  u32 crc       end of stream
+//
+// Each block is a Burrows-Wheeler transform of a run-length-encoded slice of the
+// input, move-to-front coded, then Huffman coded with up to six tables that the
+// encoder switches between every 50 symbols. Undoing that is the whole file.
+
+const BLOCK_MAGIC_HI = 0x314159;
+const BLOCK_MAGIC_LO = 0x265359;
+const EOS_MAGIC_HI = 0x177245;
+const EOS_MAGIC_LO = 0x385090;
+
+const MAX_GROUPS = 6;
+const GROUP_SIZE = 50;
+const MAX_ALPHA_SIZE = 258;
+const MAX_CODE_LEN = 23;
+const RUNA = 0;
+const RUNB = 1;
+
+// MSB-first bit reader. Reads of more than 24 bits are composed by the caller so
+// the accumulator never has to hold more than 31 bits.
+class BitReader {
+  constructor(buf) {
+    this.buf = buf;
+    this.pos = 0;
+    this.bits = 0;
+    this.count = 0;
+  }
+
+  read(n) {
+    while (this.count < n) {
+      if (this.pos >= this.buf.length) throw new Error('bzip2: input ended mid-symbol');
+      this.bits = ((this.bits << 8) | this.buf[this.pos++]) >>> 0;
+      this.count += 8;
+    }
+    this.count -= n;
+    const value = (this.bits >>> this.count) & ((1 << n) - 1);
+    this.bits &= (1 << this.count) - 1;
+    return value >>> 0;
+  }
+
+  readBit() {
+    return this.read(1);
+  }
+}
+
+// Canonical Huffman decoding tables, built from the code lengths the way the
+// reference implementation does: for each length, the smallest code (`base`) and
+// the largest (`limit`), plus the symbols in code order (`perm`).
+function buildTables(lengths, alphaSize) {
+  let minLen = MAX_CODE_LEN;
+  let maxLen = 0;
+  for (let i = 0; i < alphaSize; i++) {
+    if (lengths[i] > maxLen) maxLen = lengths[i];
+    if (lengths[i] < minLen) minLen = lengths[i];
+  }
+
+  const perm = new Int32Array(alphaSize);
+  let p = 0;
+  for (let len = minLen; len <= maxLen; len++) {
+    for (let sym = 0; sym < alphaSize; sym++) if (lengths[sym] === len) perm[p++] = sym;
+  }
+
+  const count = new Int32Array(MAX_CODE_LEN + 2);
+  for (let i = 0; i < alphaSize; i++) count[lengths[i] + 1]++;
+  for (let i = 1; i < MAX_CODE_LEN + 2; i++) count[i] += count[i - 1];
+
+  const base = new Int32Array(MAX_CODE_LEN + 2);
+  const limit = new Int32Array(MAX_CODE_LEN + 2);
+  let vec = 0;
+  for (let len = minLen; len <= maxLen; len++) {
+    vec += count[len + 1] - count[len];
+    limit[len] = vec - 1;
+    vec <<= 1;
+  }
+  for (let len = minLen + 1; len <= maxLen; len++) {
+    base[len] = ((limit[len - 1] + 1) << 1) - count[len];
+  }
+
+  return { minLen, maxLen, base, limit, perm, count };
+}
+
+function decodeSymbol(br, table) {
+  let len = table.minLen;
+  let code = br.read(len);
+  while (len <= table.maxLen && code > table.limit[len]) {
+    code = (code << 1) | br.readBit();
+    len++;
+  }
+  if (len > table.maxLen) throw new Error('bzip2: invalid Huffman code');
+  const index = code - table.base[len];
+  if (index < 0 || index >= table.perm.length) throw new Error('bzip2: Huffman symbol out of range');
+  return table.perm[index];
+}
+
+// Undo the final run-length layer: four identical bytes are followed by a count
+// of how many more of them to emit.
+function expandRuns(src, length, out, outPos) {
+  let last = -1;
+  let run = 0;
+  let o = outPos;
+  for (let i = 0; i < length; i++) {
+    const b = src[i];
+    if (run === 4) {
+      if (o + b > out.length) throw new Error('bzip2: output longer than expected');
+      out.fill(last, o, o + b);
+      o += b;
+      run = 0;
+      last = -1;
+      continue;
+    }
+    if (b === last) run++;
+    else { run = 1; last = b; }
+    if (o >= out.length) throw new Error('bzip2: output longer than expected');
+    out[o++] = b;
+  }
+  return o;
+}
+
+function decodeBlock(br, blockSize, out, outPos) {
+  br.read(24); br.read(8); // block CRC, not checked — the caller compares whole images
+  if (br.readBit()) throw new Error('bzip2: randomised blocks are not supported');
+  const origPtr = br.read(24);
+
+  // Which byte values occur, as a bitmap of 16 groups of 16.
+  const used = [];
+  const groupsUsed = br.read(16);
+  for (let group = 0; group < 16; group++) {
+    if ((groupsUsed & (0x8000 >>> group)) === 0) continue;
+    const bits = br.read(16);
+    for (let bit = 0; bit < 16; bit++) {
+      if (bits & (0x8000 >>> bit)) used.push(group * 16 + bit);
+    }
+  }
+  const symbolCount = used.length;
+  if (symbolCount === 0) throw new Error('bzip2: block uses no symbols');
+  const alphaSize = symbolCount + 2;
+
+  const groupCount = br.read(3);
+  if (groupCount < 2 || groupCount > MAX_GROUPS) throw new Error('bzip2: bad table count');
+  const selectorCount = br.read(15);
+
+  // Selectors are move-to-front coded over the table numbers.
+  const mtfGroups = new Int32Array(MAX_GROUPS);
+  for (let i = 0; i < groupCount; i++) mtfGroups[i] = i;
+  const selectors = new Int32Array(selectorCount);
+  for (let i = 0; i < selectorCount; i++) {
+    let j = 0;
+    while (br.readBit()) {
+      if (++j >= groupCount) throw new Error('bzip2: selector out of range');
+    }
+    const value = mtfGroups[j];
+    for (let k = j; k > 0; k--) mtfGroups[k] = mtfGroups[k - 1];
+    mtfGroups[0] = value;
+    selectors[i] = value;
+  }
+
+  // Code lengths are delta coded, one walk per table.
+  const tables = [];
+  for (let t = 0; t < groupCount; t++) {
+    const lengths = new Int32Array(MAX_ALPHA_SIZE);
+    let len = br.read(5);
+    for (let sym = 0; sym < alphaSize; sym++) {
+      while (br.readBit()) len += br.readBit() ? -1 : 1;
+      if (len < 1 || len > MAX_CODE_LEN) throw new Error('bzip2: code length out of range');
+      lengths[sym] = len;
+    }
+    tables.push(buildTables(lengths, alphaSize));
+  }
+
+  // Huffman + move-to-front + zero-run decoding, straight into the BWT string.
+  const limit = blockSize * 100000;
+  const bwt = Buffer.allocUnsafe(limit);
+  const byteCount = new Int32Array(256);
+  const mtf = Int32Array.from(used);
+  const eob = alphaSize - 1;
+
+  let bwtLength = 0;
+  let selector = 0;
+  let inGroup = 0;
+  let table = null;
+  let runLength = 0;
+  let runBit = 0;
+
+  const flushRun = () => {
+    if (runLength === 0) return;
+    const value = mtf[0];
+    if (bwtLength + runLength > limit) throw new Error('bzip2: block longer than its declared size');
+    bwt.fill(value, bwtLength, bwtLength + runLength);
+    byteCount[value] += runLength;
+    bwtLength += runLength;
+    runLength = 0;
+    runBit = 0;
+  };
+
+  for (;;) {
+    if (inGroup === 0) {
+      if (selector >= selectorCount) throw new Error('bzip2: ran out of selectors');
+      table = tables[selectors[selector++]];
+      inGroup = GROUP_SIZE;
+    }
+    inGroup--;
+    const symbol = decodeSymbol(br, table);
+
+    if (symbol === RUNA || symbol === RUNB) {
+      // A run of the current front-of-list byte, in bijective base 2.
+      runLength += (symbol === RUNA ? 1 : 2) << runBit;
+      runBit++;
+      continue;
+    }
+    flushRun();
+    if (symbol === eob) break;
+
+    // Any other symbol is a move-to-front index, offset by one because RUNA and
+    // RUNB took index 0.
+    const index = symbol - 1;
+    if (index >= symbolCount) throw new Error('bzip2: MTF index out of range');
+    const value = mtf[index];
+    for (let k = index; k > 0; k--) mtf[k] = mtf[k - 1];
+    mtf[0] = value;
+    if (bwtLength >= limit) throw new Error('bzip2: block longer than its declared size');
+    bwt[bwtLength++] = value;
+    byteCount[value]++;
+  }
+
+  if (origPtr >= bwtLength) throw new Error('bzip2: BWT pointer past the end of the block');
+
+  // Inverse Burrows-Wheeler: tt[i] is the position of the character that follows
+  // the one at i in the original string, so walking it from origPtr reads the
+  // block back out in order.
+  const cumulative = new Int32Array(256);
+  let total = 0;
+  for (let i = 0; i < 256; i++) { cumulative[i] = total; total += byteCount[i]; }
+  const tt = new Int32Array(bwtLength);
+  for (let i = 0; i < bwtLength; i++) tt[cumulative[bwt[i]]++] = i;
+
+  const plain = Buffer.allocUnsafe(bwtLength);
+  let p = tt[origPtr];
+  for (let i = 0; i < bwtLength; i++) {
+    plain[i] = bwt[p];
+    p = tt[p];
+  }
+
+  return expandRuns(plain, bwtLength, out, outPos);
+}
+
+/**
+ * Decompress a complete bzip2 stream. `maxSize` bounds the output — WIA/RVZ
+ * always knows how large a group decompresses to, so a corrupt stream cannot be
+ * made to allocate without limit.
+ */
+export function bzip2Decompress(input, maxSize) {
+  if (input.length < 4 || input[0] !== 0x42 || input[1] !== 0x5a || input[2] !== 0x68) {
+    throw new Error('bzip2: missing BZh signature');
+  }
+  const blockSize = input[3] - 0x30;
+  if (blockSize < 1 || blockSize > 9) throw new Error('bzip2: bad block size');
+
+  const br = new BitReader(input);
+  br.pos = 4;
+  const out = Buffer.allocUnsafe(maxSize);
+  let outPos = 0;
+
+  for (;;) {
+    const hi = br.read(24);
+    const lo = br.read(24);
+    if (hi === EOS_MAGIC_HI && lo === EOS_MAGIC_LO) {
+      br.read(24); br.read(8); // combined CRC
+      break;
+    }
+    if (hi !== BLOCK_MAGIC_HI || lo !== BLOCK_MAGIC_LO) throw new Error('bzip2: lost block alignment');
+    outPos = decodeBlock(br, blockSize, out, outPos);
+  }
+
+  return out.subarray(0, outPos);
+}

--- a/server/src/hashing/expand.js
+++ b/server/src/hashing/expand.js
@@ -5,9 +5,10 @@
 // return the same shape, so callers only need this one entry point.
 import { isCsoPath, expandCso } from './cso.js';
 import { isRvzPath, expandRvz } from './rvz.js';
+import { isGczPath, expandGcz } from './gcz.js';
 
 export function isCompressedDisc(filePath) {
-  return isCsoPath(filePath) || isRvzPath(filePath);
+  return isCsoPath(filePath) || isRvzPath(filePath) || isGczPath(filePath);
 }
 
 /**
@@ -22,5 +23,6 @@ export async function expandDiscImage(filePath, displayPath, options) {
   const name = displayPath ?? filePath;
   if (isCsoPath(name)) return expandCso(filePath, options);
   if (isRvzPath(name)) return expandRvz(filePath, options);
+  if (isGczPath(name)) return expandGcz(filePath, options);
   return null;
 }

--- a/server/src/hashing/gcz.js
+++ b/server/src/hashing/gcz.js
@@ -1,0 +1,155 @@
+// GCZ (Dolphin's older compressed GameCube/Wii image) support.
+//
+// RAHasher cannot open one — it reads the GCZ header as if it were the disc and
+// reports "Not a Gamecube disc" — so a .gcz is expanded back into a plain .iso in
+// the temp folder, the same as .cso and .rvz.
+//
+// The format is a plain block container, simpler than either of those: the image
+// is cut into fixed-size blocks, each deflated or stored, with a table of where
+// each one starts.
+//
+//   0x00  u32  magic          0xB10BC001
+//   0x04  u32  sub_type
+//   0x08  u64  compressed size of the data area
+//   0x10  u64  size of the original image
+//   0x18  u32  block size
+//   0x1c  u32  block count
+//   0x20  u64  offset per block, relative to the data area; bit 63 = stored raw
+//   ...   u32  Adler-32 per block, over the bytes as stored
+//   ...        the data area
+//
+// Everything is little endian, which is the one thing it does not share with
+// WIA/RVZ.
+import { open, stat, unlink, statfs } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { once } from 'node:events';
+import { join, basename, extname } from 'node:path';
+import { inflateSync } from 'node:zlib';
+import { config } from '../config.js';
+
+const GCZ_MAGIC = 0xb10bc001;
+const HEADER_SIZE = 0x20;
+const MAX_BLOCK_SIZE = 16 << 20;
+const STORED_FLAG = 1n << 63n;
+
+export function isGczPath(filePath) {
+  return extname(String(filePath)).toLowerCase() === '.gcz';
+}
+
+async function readExact(fh, size, position) {
+  const buf = Buffer.alloc(size);
+  let got = 0;
+  while (got < size) {
+    const { bytesRead } = await fh.read(buf, got, size - got, position + got);
+    if (bytesRead === 0) throw new Error(`file ends at ${position + got}, wanted ${position + size}`);
+    got += bytesRead;
+  }
+  return buf;
+}
+
+// Parse the header and the block table. Returns null when the file is not a GCZ,
+// so the caller can hash it exactly as before.
+async function readGczIndex(fh, fileSize) {
+  const head = Buffer.alloc(HEADER_SIZE);
+  const { bytesRead } = await fh.read(head, 0, HEADER_SIZE, 0);
+  if (bytesRead < HEADER_SIZE) return null;
+  if (head.readUInt32LE(0) !== GCZ_MAGIC) return null;
+
+  const dataSize = Number(head.readBigUInt64LE(0x10));
+  const blockSize = head.readUInt32LE(0x18);
+  const blocks = head.readUInt32LE(0x1c);
+
+  if (!Number.isSafeInteger(dataSize) || dataSize <= 0) throw new Error('implausible image size');
+  if (blockSize < 512 || blockSize > MAX_BLOCK_SIZE) throw new Error(`implausible block size ${blockSize}`);
+  if (blocks !== Math.ceil(dataSize / blockSize)) throw new Error('block count does not match the image size');
+
+  const offsets = await readExact(fh, blocks * 8, HEADER_SIZE);
+  const dataStart = HEADER_SIZE + blocks * 8 + blocks * 4;
+  if (dataStart > fileSize) throw new Error('the block table runs past the end of the file');
+
+  return { dataSize, blockSize, blocks, offsets, dataStart };
+}
+
+// Is there room in temp for the expanded image (plus 15% headroom)?
+async function tempHasRoom(bytes) {
+  try {
+    const fs = await statfs(config.tempDir);
+    return fs.bavail * fs.bsize >= bytes * 1.15;
+  } catch { return true; }
+}
+
+/**
+ * Expand a .gcz into a plain .iso in the temp folder.
+ *
+ * Returns { path, cleanup, size } on success, { error } when it cannot be read,
+ * or null when the file is not a GCZ at all. `onProgress(done, total)` reports
+ * written bytes.
+ */
+export async function expandGcz(filePath, { signal, onProgress } = {}) {
+  const fh = await open(filePath, 'r');
+  const fileSize = (await stat(filePath)).size;
+  let index;
+  try {
+    index = await readGczIndex(fh, fileSize);
+  } catch (e) {
+    await fh.close();
+    return { error: `Could not read the GCZ header: ${String(e.message).slice(0, 160)}` };
+  }
+  if (!index) {
+    await fh.close();
+    return null;
+  }
+
+  const { dataSize, blockSize, blocks, offsets, dataStart } = index;
+  if (!(await tempHasRoom(dataSize))) {
+    await fh.close();
+    const gb = (dataSize / 1024 ** 3).toFixed(1);
+    return { error: `Not enough free space in the temp folder to expand this GCZ (needs about ${gb} GB).` };
+  }
+
+  const dest = join(config.tempDir, `gcz-${process.pid}-${Date.now()}-${basename(filePath, extname(filePath))}.iso`);
+  const cleanup = async () => { try { await unlink(dest); } catch { /* best effort */ } };
+  const ws = createWriteStream(dest);
+
+  // A block's stored length is the distance to the next one; the last one runs to
+  // the end of the file.
+  const rawOffset = (i) => offsets.readBigUInt64LE(i * 8);
+  const startOf = (i) => Number(rawOffset(i) & ~STORED_FLAG) + dataStart;
+  const isStored = (i) => (rawOffset(i) & STORED_FLAG) !== 0n;
+
+  let written = 0;
+  try {
+    for (let i = 0; i < blocks; i++) {
+      if (signal?.aborted) throw new Error('aborted');
+      const start = startOf(i);
+      const end = i + 1 < blocks ? startOf(i + 1) : fileSize;
+      if (end <= start || end > fileSize) throw new Error(`block ${i} has an invalid offset`);
+
+      const packed = await readExact(fh, end - start, start);
+      const wanted = Math.min(blockSize, dataSize - written);
+      let plain;
+      if (isStored(i)) {
+        plain = packed.subarray(0, wanted);
+      } else {
+        const out = inflateSync(packed);
+        if (out.length < wanted) throw new Error(`block ${i} inflated to ${out.length} of ${wanted} bytes`);
+        plain = out.subarray(0, wanted);
+      }
+
+      if (!ws.write(plain)) await once(ws, 'drain');
+      written += plain.length;
+      if ((i & 63) === 0) onProgress?.(written, dataSize);
+    }
+    ws.end();
+    await once(ws, 'finish');
+    onProgress?.(written, dataSize);
+    return { path: dest, cleanup, size: written };
+  } catch (e) {
+    ws.destroy();
+    await cleanup();
+    if (signal?.aborted) throw e;
+    return { error: `Could not expand the GCZ: ${String(e.message).slice(0, 160)}` };
+  } finally {
+    await fh.close();
+  }
+}

--- a/server/src/hashing/lzma.js
+++ b/server/src/hashing/lzma.js
@@ -1,0 +1,350 @@
+// LZMA and LZMA2 decompression.
+//
+// WIA/RVZ can compress its groups with either, and Node has no decoder for them.
+// The published decoders on npm are no help here: the native ones would have to
+// be rebuilt against Electron's ABI, and the pure-JavaScript ones only speak the
+// ".lzma alone" container — WIA/RVZ stores a *raw* stream with no header at all,
+// its lc/lp/pb and dictionary size living in wia_disc_t.compr_data instead. So
+// the decoder is written out here, following the reference LzmaSpec.cpp.
+//
+// LZMA is a range coder over an adaptive bit model. Each step decodes either a
+// literal byte or a (length, distance) match reaching back into what has already
+// been produced; the last four distances are remembered, so a repeat costs
+// almost nothing. LZMA2 wraps that in chunks, each of which may reset the
+// probabilities, the properties or the dictionary.
+
+const PROB_INIT = 1 << 10; // half of 1 << 11
+const TOP_VALUE = 1 << 24;
+const NUM_POS_BITS_MAX = 4;
+const NUM_STATES = 12;
+const NUM_LEN_TO_POS_STATES = 4;
+const NUM_ALIGN_BITS = 4;
+const END_POS_MODEL_INDEX = 14;
+const NUM_FULL_DISTANCES = 1 << (END_POS_MODEL_INDEX >> 1); // 128
+const MATCH_MIN_LEN = 2;
+
+// One length coder packed into a single array: choice, choice2, then the 3-bit
+// low and mid trees per position state and the shared 8-bit high tree.
+const LEN_CHOICE = 0;
+const LEN_CHOICE2 = 1;
+const LEN_LOW = 2;
+const LEN_MID = LEN_LOW + (1 << NUM_POS_BITS_MAX) * 8; // 130
+const LEN_HIGH = LEN_MID + (1 << NUM_POS_BITS_MAX) * 8; // 258
+const LEN_SIZE = LEN_HIGH + 256;
+
+class RangeDecoder {
+  constructor(buf, start, end) {
+    this.buf = buf;
+    this.pos = start;
+    this.end = end;
+    this.range = 0xffffffff;
+    this.code = 0;
+    // Set once the decoder reads past the end of its slice. From then on it is
+    // fed zeroes, which lets a stream with no end marker run to the length the
+    // caller asked for instead of failing mid-symbol.
+    this.exhausted = false;
+    this.nextByte(); // the first byte of a stream is always 0 and is discarded
+    for (let i = 0; i < 4; i++) this.code = ((this.code << 8) | this.nextByte()) >>> 0;
+  }
+
+  nextByte() {
+    if (this.pos < this.end) return this.buf[this.pos++];
+    this.exhausted = true;
+    return 0;
+  }
+
+  normalize() {
+    if (this.range >>> 0 < TOP_VALUE) {
+      this.range = (this.range << 8) >>> 0;
+      this.code = ((this.code << 8) | this.nextByte()) >>> 0;
+    }
+  }
+
+  decodeBit(probs, index) {
+    const p = probs[index];
+    const bound = ((this.range >>> 11) * p) >>> 0;
+    let bit;
+    if ((this.code >>> 0) < bound) {
+      this.range = bound;
+      probs[index] = p + ((2048 - p) >>> 5);
+      bit = 0;
+    } else {
+      this.range = (this.range - bound) >>> 0;
+      this.code = (this.code - bound) >>> 0;
+      probs[index] = p - (p >>> 5);
+      bit = 1;
+    }
+    this.normalize();
+    return bit;
+  }
+
+  // Bits the coder stores flat, without a probability model.
+  decodeDirect(count) {
+    let result = 0;
+    for (let i = 0; i < count; i++) {
+      this.range = this.range >>> 1;
+      this.code = (this.code - this.range) >>> 0;
+      let bit;
+      if (this.code >>> 31) { this.code = (this.code + this.range) >>> 0; bit = 0; }
+      else bit = 1;
+      this.normalize();
+      result = result * 2 + bit;
+    }
+    return result;
+  }
+
+  bitTree(probs, offset, numBits) {
+    let m = 1;
+    for (let i = 0; i < numBits; i++) m = (m << 1) + this.decodeBit(probs, offset + m);
+    return m - (1 << numBits);
+  }
+
+  bitTreeReverse(probs, offset, numBits) {
+    let m = 1;
+    let symbol = 0;
+    for (let i = 0; i < numBits; i++) {
+      const bit = this.decodeBit(probs, offset + m);
+      m = (m << 1) + bit;
+      symbol |= bit << i;
+    }
+    return symbol;
+  }
+
+  isFinished() {
+    return this.code === 0;
+  }
+}
+
+class LzmaDecoder {
+  constructor() {
+    this.isMatch = new Uint16Array(NUM_STATES << NUM_POS_BITS_MAX);
+    this.isRep = new Uint16Array(NUM_STATES);
+    this.isRepG0 = new Uint16Array(NUM_STATES);
+    this.isRepG1 = new Uint16Array(NUM_STATES);
+    this.isRepG2 = new Uint16Array(NUM_STATES);
+    this.isRep0Long = new Uint16Array(NUM_STATES << NUM_POS_BITS_MAX);
+    this.posSlot = new Uint16Array(NUM_LEN_TO_POS_STATES * 64);
+    this.posDecoders = new Uint16Array(1 + NUM_FULL_DISTANCES - END_POS_MODEL_INDEX);
+    this.align = new Uint16Array(1 << NUM_ALIGN_BITS);
+    this.lenCoder = new Uint16Array(LEN_SIZE);
+    this.repLenCoder = new Uint16Array(LEN_SIZE);
+    this.literal = new Uint16Array(0);
+    this.setProps(3, 0, 2);
+    this.resetState();
+  }
+
+  setProps(lc, lp, pb) {
+    if (lc > 8 || lp > 4 || pb > 4) throw new Error('lzma: properties out of range');
+    this.lc = lc;
+    this.lp = lp;
+    this.pb = pb;
+    const size = 0x300 << (lc + lp);
+    if (this.literal.length !== size) this.literal = new Uint16Array(size);
+  }
+
+  setPropsByte(byte) {
+    if (byte >= 9 * 5 * 5) throw new Error('lzma: invalid properties byte');
+    const lc = byte % 9;
+    const rest = (byte - lc) / 9;
+    this.setProps(lc, rest % 5, (rest - (rest % 5)) / 5);
+  }
+
+  resetState() {
+    for (const a of [this.isMatch, this.isRep, this.isRepG0, this.isRepG1, this.isRepG2,
+      this.isRep0Long, this.posSlot, this.posDecoders, this.align, this.lenCoder,
+      this.repLenCoder, this.literal]) a.fill(PROB_INIT);
+    this.state = 0;
+    this.rep0 = 0;
+    this.rep1 = 0;
+    this.rep2 = 0;
+    this.rep3 = 0;
+  }
+
+  decodeLen(rc, probs, posState) {
+    if (rc.decodeBit(probs, LEN_CHOICE) === 0) return rc.bitTree(probs, LEN_LOW + posState * 8, 3);
+    if (rc.decodeBit(probs, LEN_CHOICE2) === 0) return 8 + rc.bitTree(probs, LEN_MID + posState * 8, 3);
+    return 16 + rc.bitTree(probs, LEN_HIGH, 8);
+  }
+
+  decodeDistance(rc, len) {
+    const lenState = Math.min(len, NUM_LEN_TO_POS_STATES - 1);
+    const slot = rc.bitTree(this.posSlot, lenState * 64, 6);
+    if (slot < 4) return slot;
+    const numDirect = (slot >> 1) - 1;
+    let dist = (2 | (slot & 1)) * Math.pow(2, numDirect);
+    if (slot < END_POS_MODEL_INDEX) {
+      dist += rc.bitTreeReverse(this.posDecoders, dist - slot, numDirect);
+    } else {
+      dist += rc.decodeDirect(numDirect - NUM_ALIGN_BITS) * (1 << NUM_ALIGN_BITS);
+      dist += rc.bitTreeReverse(this.align, 0, NUM_ALIGN_BITS);
+    }
+    return dist;
+  }
+
+  /**
+   * Decode into `out[outPos..outEnd)`, treating `out[dictStart..outPos)` as the
+   * dictionary. Returns the new output position. Stops on the end marker, on a
+   * full output, or — when `tolerateEnd` is set — as soon as the input runs out,
+   * which is how a raw LZMA1 stream with neither an end marker nor a stored
+   * length is read.
+   */
+  decode(rc, out, outPos, outEnd, dictStart, tolerateEnd) {
+    const posMask = (1 << this.pb) - 1;
+    const litPosMask = (1 << this.lp) - 1;
+
+    while (outPos < outEnd) {
+      if (tolerateEnd && rc.exhausted && rc.isFinished()) break;
+      const position = outPos - dictStart;
+      const posState = position & posMask;
+
+      if (rc.decodeBit(this.isMatch, (this.state << NUM_POS_BITS_MAX) + posState) === 0) {
+        const prev = outPos > dictStart ? out[outPos - 1] : 0;
+        const litState = ((position & litPosMask) << this.lc) + (prev >>> (8 - this.lc));
+        const base = 0x300 * litState;
+        let symbol = 1;
+        if (this.state >= 7) {
+          // After a match, the byte at the same distance is used as a hint.
+          let matchByte = out[outPos - this.rep0 - 1];
+          do {
+            const matchBit = (matchByte >> 7) & 1;
+            matchByte = (matchByte << 1) & 0xff;
+            const bit = rc.decodeBit(this.literal, base + ((1 + matchBit) << 8) + symbol);
+            symbol = (symbol << 1) | bit;
+            if (matchBit !== bit) break;
+          } while (symbol < 0x100);
+        }
+        while (symbol < 0x100) symbol = (symbol << 1) | rc.decodeBit(this.literal, base + symbol);
+        out[outPos++] = symbol & 0xff;
+        this.state = this.state < 4 ? 0 : this.state < 10 ? this.state - 3 : this.state - 6;
+        continue;
+      }
+
+      let len;
+      if (rc.decodeBit(this.isRep, this.state) !== 0) {
+        if (outPos === dictStart) throw new Error('lzma: repeat before any output');
+        if (rc.decodeBit(this.isRepG0, this.state) === 0) {
+          if (rc.decodeBit(this.isRep0Long, (this.state << NUM_POS_BITS_MAX) + posState) === 0) {
+            this.state = this.state < 7 ? 9 : 11;
+            out[outPos] = out[outPos - this.rep0 - 1];
+            outPos++;
+            continue;
+          }
+        } else {
+          let dist;
+          if (rc.decodeBit(this.isRepG1, this.state) === 0) dist = this.rep1;
+          else {
+            if (rc.decodeBit(this.isRepG2, this.state) === 0) dist = this.rep2;
+            else { dist = this.rep3; this.rep3 = this.rep2; }
+            this.rep2 = this.rep1;
+          }
+          this.rep1 = this.rep0;
+          this.rep0 = dist;
+        }
+        len = this.decodeLen(rc, this.repLenCoder, posState);
+        this.state = this.state < 7 ? 8 : 11;
+      } else {
+        this.rep3 = this.rep2;
+        this.rep2 = this.rep1;
+        this.rep1 = this.rep0;
+        len = this.decodeLen(rc, this.lenCoder, posState);
+        this.state = this.state < 7 ? 7 : 10;
+        const dist = this.decodeDistance(rc, len);
+        if (dist === 0xffffffff) return outPos; // end-of-stream marker
+        this.rep0 = dist;
+        if (dist >= outPos - dictStart) throw new Error('lzma: match reaches before the dictionary');
+      }
+
+      len += MATCH_MIN_LEN;
+      // A match may legitimately run past the end of what the caller asked for;
+      // the reference decoder truncates it too.
+      if (outPos + len > outEnd) len = outEnd - outPos;
+      let from = outPos - this.rep0 - 1;
+      for (let i = 0; i < len; i++) out[outPos++] = out[from++];
+    }
+    return outPos;
+  }
+}
+
+/**
+ * Decode a raw LZMA1 stream — no container, no header. `propsByte` carries
+ * lc/lp/pb (WIA/RVZ keeps it in wia_disc_t.compr_data). `maxSize` is how much
+ * output to produce at most; a stream that ends earlier stops on its own.
+ */
+export function lzma1Decompress(input, propsByte, maxSize) {
+  const decoder = new LzmaDecoder();
+  decoder.setPropsByte(propsByte);
+  decoder.resetState();
+  const out = Buffer.alloc(maxSize);
+  const rc = new RangeDecoder(input, 0, input.length);
+  let produced = 0;
+  try {
+    produced = decoder.decode(rc, out, 0, maxSize, 0, true);
+  } catch (e) {
+    // Without a stored length the decoder can only find the end by running into
+    // it. Everything decoded before that point is still valid, and WIA/RVZ never
+    // reads further than the group's declared size.
+    if (!rc.exhausted) throw e;
+  }
+  return out.subarray(0, produced);
+}
+
+/**
+ * Decode a raw LZMA2 stream: a sequence of chunks, each either stored or LZMA
+ * coded, with its own flags for resetting the state, the properties and the
+ * dictionary. Self-terminating, so `maxSize` is only a bound on the output.
+ */
+export function lzma2Decompress(input, maxSize) {
+  const decoder = new LzmaDecoder();
+  const out = Buffer.alloc(maxSize);
+  let outPos = 0;
+  let dictStart = 0;
+  let pos = 0;
+  let propsSeen = false;
+
+  while (pos < input.length) {
+    const control = input[pos++];
+    if (control === 0) break;
+
+    if (control < 3) {
+      // A stored chunk. It also drops the coder state, so the next LZMA chunk
+      // has to bring its own reset — which the format guarantees.
+      if (control === 1) dictStart = outPos;
+      if (pos + 2 > input.length) throw new Error('lzma2: truncated chunk header');
+      const size = ((input[pos] << 8) | input[pos + 1]) + 1;
+      pos += 2;
+      if (pos + size > input.length) throw new Error('lzma2: stored chunk runs past the input');
+      if (outPos + size > maxSize) throw new Error('lzma2: output longer than expected');
+      input.copy(out, outPos, pos, pos + size);
+      outPos += size;
+      pos += size;
+      decoder.resetState();
+      continue;
+    }
+
+    if (control < 0x80) throw new Error(`lzma2: reserved control byte 0x${control.toString(16)}`);
+    if (pos + 4 > input.length) throw new Error('lzma2: truncated chunk header');
+    const unpackSize = (((control & 0x1f) << 16) | (input[pos] << 8) | input[pos + 1]) + 1;
+    const packSize = ((input[pos + 2] << 8) | input[pos + 3]) + 1;
+    pos += 4;
+
+    const reset = (control >> 5) & 3;
+    if (reset >= 2) {
+      if (pos >= input.length) throw new Error('lzma2: truncated properties');
+      decoder.setPropsByte(input[pos++]);
+      propsSeen = true;
+    }
+    if (!propsSeen) throw new Error('lzma2: first chunk carries no properties');
+    if (reset >= 1) decoder.resetState();
+    if (reset === 3) dictStart = outPos;
+
+    if (pos + packSize > input.length) throw new Error('lzma2: chunk runs past the input');
+    if (outPos + unpackSize > maxSize) throw new Error('lzma2: output longer than expected');
+    const rc = new RangeDecoder(input, pos, pos + packSize);
+    const end = decoder.decode(rc, out, outPos, outPos + unpackSize, dictStart, false);
+    if (end !== outPos + unpackSize) throw new Error('lzma2: chunk decoded short');
+    outPos = end;
+    pos += packSize;
+  }
+
+  return out.subarray(0, outPos);
+}

--- a/server/src/hashing/rvz.js
+++ b/server/src/hashing/rvz.js
@@ -32,6 +32,8 @@ import { join, basename, extname } from 'node:path';
 import { createHash, createCipheriv } from 'node:crypto';
 import { zstdDecompressSync } from 'node:zlib';
 import { config } from '../config.js';
+import { bzip2Decompress } from './bzip2.js';
+import { lzma1Decompress, lzma2Decompress } from './lzma.js';
 
 export const RVZ_EXTS = new Set(['.rvz', '.wia']);
 
@@ -48,9 +50,7 @@ const DISC_TYPE_WII = 2;
 
 const COMPRESSION = { NONE: 0, PURGE: 1, BZIP2: 2, LZMA: 3, LZMA2: 4, ZSTD: 5 };
 const COMPRESSION_NAMES = ['none', 'Purge', 'bzip2', 'LZMA', 'LZMA2', 'Zstandard'];
-// Node ships a Zstandard decoder; bzip2/LZMA/LZMA2 would each need a decoder of
-// their own. Zstandard is what Dolphin defaults to, so those three are rare.
-const SUPPORTED_COMPRESSION = new Set([COMPRESSION.NONE, COMPRESSION.PURGE, COMPRESSION.ZSTD]);
+const SUPPORTED_COMPRESSION = new Set(Object.values(COMPRESSION));
 
 // Wii disc geometry. A sector is 0x8000 bytes on disc: a 0x400 hash block
 // followed by 0x7c00 bytes of encrypted payload.
@@ -75,10 +75,21 @@ async function readExact(fh, size, position) {
 
 // Whole-stream codecs. PURGE is not one of these — it is a sparse-segment
 // encoding applied to the group payload itself, decoded by decodePurge.
-function decompressStream(method, input) {
-  if (method === COMPRESSION.NONE) return input;
-  if (method === COMPRESSION.ZSTD) return zstdDecompressSync(input);
-  throw new Error(`compression method ${COMPRESSION_NAMES[method] ?? method} is not supported`);
+//
+// `maxSize` is how much output the caller can possibly need. bzip2 and LZMA2 use
+// it only to bound their allocation; raw LZMA1 needs it as the target length,
+// because the format stores neither a length nor, in Dolphin's writer, an
+// end-of-stream marker.
+function decompressStream(method, input, comprData, maxSize) {
+  switch (method) {
+    case COMPRESSION.NONE: return input;
+    case COMPRESSION.ZSTD: return zstdDecompressSync(input);
+    case COMPRESSION.BZIP2: return bzip2Decompress(input, maxSize);
+    case COMPRESSION.LZMA: return lzma1Decompress(input, comprData[0], maxSize);
+    case COMPRESSION.LZMA2: return lzma2Decompress(input, maxSize);
+    default:
+      throw new Error(`compression method ${COMPRESSION_NAMES[method] ?? method} is not supported`);
+  }
 }
 
 // PURGE (WIA only): a run of {offset, size, data} segments covering the parts of
@@ -274,6 +285,9 @@ async function readRvzHeader(fh) {
     compression: disc.readUInt32BE(0x04),
     chunkSize: disc.readUInt32BE(0x0c),
     discHead: Buffer.from(disc.subarray(0x10, 0x90)),
+    // Codec parameters: the LZMA properties byte and dictionary size for LZMA,
+    // the dictionary size property for LZMA2, unused by the others.
+    comprData: Buffer.from(disc.subarray(0xd5, 0xdc)),
     groupEntrySize: isRvz ? 12 : 8,
   };
 
@@ -297,10 +311,9 @@ async function readRvzHeader(fh) {
   const groupSize = disc.readUInt32BE(0xd0);
 
   if (!SUPPORTED_COMPRESSION.has(ctx.compression)) {
-    const name = COMPRESSION_NAMES[ctx.compression] ?? `type ${ctx.compression}`;
     const err = new Error(
-      `this image is compressed with ${name}; RAChecker can only read Zstandard-compressed ones. ` +
-      'Re-compress it in Dolphin (Convert File… → Zstandard) and scan it again'
+      `this image uses compression type ${ctx.compression}, which RAChecker does not know. ` +
+      'It is newer than the documented WIA/RVZ format — please report the file'
     );
     err.unsupportedCompression = true;
     throw err;
@@ -330,7 +343,7 @@ async function readRvzHeader(fh) {
 
   const readTable = async (offset, packedSize, expected) => {
     const raw = await readExact(fh, packedSize, offset);
-    const table = decompressStream(ctx.compression, raw);
+    const table = decompressStream(ctx.compression, raw, ctx.comprData, expected);
     if (table.length < expected) throw new Error('a table decompressed to fewer bytes than it declares');
     return table;
   };
@@ -378,9 +391,19 @@ async function decodeGroup(ctx, fh, index, { logicalSize, exceptionLists, baseDi
 
   const method = compressed ? ctx.compression : COMPRESSION.NONE;
   const raw = await readExact(fh, storedSize, group.dataOffset);
+  // How much this group can possibly decompress to. The payload's size is known
+  // up front; the exception lists in front of it are not, so they are bounded —
+  // a sector's 0x400-byte hash block holds at most 47 hashes (31 H0, 8 H1, 8 H2)
+  // and one list covers at most a 64-sector group.
+  const payloadSize = group.packedSize > 0 ? group.packedSize : logicalSize;
+  const maxSize = payloadSize + (exceptionLists > 0
+    ? exceptionLists * (2 + SECTORS_PER_GROUP * 47 * 22) + 4
+    : 0);
   // Purge is applied to the payload only, so its exception lists sit in front of
   // the still-encoded data rather than inside a decompressed stream.
-  const stream = method === COMPRESSION.PURGE ? raw : decompressStream(method, raw);
+  const stream = method === COMPRESSION.PURGE
+    ? raw
+    : decompressStream(method, raw, ctx.comprData, maxSize);
 
   let pos = 0;
   const exceptions = [];

--- a/server/test/gcz.test.js
+++ b/server/test/gcz.test.js
@@ -1,0 +1,127 @@
+// Tests for GCZ expansion (server/src/hashing/gcz.js).
+//
+// A GCZ is an image cut into fixed-size blocks, each deflated or stored, plus a
+// table of block offsets. These tests build one from a known image, expand it
+// again and require the result to be byte-identical — that equality is what makes
+// the RetroAchievements hash RAHasher then produces trustworthy.
+//
+// gcz.js writes the expanded image into config.tempDir, so RA_DATA_DIR points at
+// a throwaway directory BEFORE the import.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { deflateSync } from 'node:zlib';
+
+const tempDataDir = mkdtempSync(join(tmpdir(), 'ra-checker-gcz-'));
+process.env.RA_DATA_DIR = tempDataDir;
+
+let gcz;
+before(async () => { gcz = await import('../src/hashing/gcz.js'); });
+after(() => { try { rmSync(tempDataDir, { recursive: true, force: true }); } catch { /* windows file locks */ } });
+
+const BLOCK = 0x8000;
+
+// Deterministic content: runs that deflate to nothing next to noise that does not
+// compress at all, so both the stored and the deflated block paths are used.
+function makeImage(blocks, tailBytes = BLOCK) {
+  const total = (blocks - 1) * BLOCK + tailBytes;
+  const buf = Buffer.alloc(total);
+  let s = 0x2545f491;
+  for (let i = 0; i < total; i++) {
+    s = (Math.imul(s, 1103515245) + 12345) >>> 0;
+    buf[i] = Math.floor(i / BLOCK) % 3 === 0 ? 0x41 : (s >>> 16) & 0xff;
+  }
+  buf.writeUInt32BE(0xc2339f3d, 0x1c); // the GameCube magic word
+  return buf;
+}
+
+const adler32 = (buf) => {
+  let a = 1;
+  let b = 0;
+  for (const x of buf) { a = (a + x) % 65521; b = (b + a) % 65521; }
+  return ((b << 16) | a) >>> 0;
+};
+
+// Pack an image the way Dolphin does: blocks that do not get smaller are stored
+// verbatim and flagged with bit 63 of their offset.
+function packGcz(image, { blockSize = BLOCK, corrupt } = {}) {
+  const blocks = Math.ceil(image.length / blockSize);
+  const offsets = Buffer.alloc(blocks * 8);
+  const hashes = Buffer.alloc(blocks * 4);
+  const parts = [];
+  let cursor = 0n;
+  for (let i = 0; i < blocks; i++) {
+    const plain = image.subarray(i * blockSize, Math.min((i + 1) * blockSize, image.length));
+    const packed = deflateSync(plain);
+    const stored = packed.length >= plain.length;
+    const bytes = stored ? plain : packed;
+    offsets.writeBigUInt64LE(cursor | (stored ? 1n << 63n : 0n), i * 8);
+    hashes.writeUInt32LE(adler32(bytes), i * 4);
+    parts.push(bytes);
+    cursor += BigInt(bytes.length);
+  }
+  const data = Buffer.concat(parts);
+  const head = Buffer.alloc(0x20);
+  head.writeUInt32LE(corrupt?.magic ?? 0xb10bc001, 0x00);
+  head.writeUInt32LE(0, 0x04);
+  head.writeBigUInt64LE(BigInt(data.length), 0x08);
+  head.writeBigUInt64LE(BigInt(image.length), 0x10);
+  head.writeUInt32LE(corrupt?.blockSize ?? blockSize, 0x18);
+  head.writeUInt32LE(corrupt?.blocks ?? blocks, 0x1c);
+  return Buffer.concat([head, offsets, hashes, data]);
+}
+
+let fixtureNo = 0;
+async function roundTrip(file, expected) {
+  const path = join(tempDataDir, `fixture-${fixtureNo++}.gcz`);
+  writeFileSync(path, file);
+  const result = await gcz.expandGcz(path);
+  assert.equal(result?.error, undefined, `expandGcz failed: ${result?.error}`);
+  try {
+    const got = readFileSync(result.path);
+    assert.equal(got.length, expected.length, 'expanded image has the wrong length');
+    if (!got.equals(expected)) {
+      const at = got.findIndex((b, i) => b !== expected[i]);
+      assert.fail(`expanded image differs from the reference at 0x${at.toString(16)}`);
+    }
+  } finally {
+    await result.cleanup();
+  }
+}
+
+test('GCZ: an image round-trips byte for byte', async () => {
+  const image = makeImage(9);
+  await roundTrip(packGcz(image), image);
+});
+
+test('GCZ: a trailing partial block round-trips', async () => {
+  const image = makeImage(6, 1234);
+  await roundTrip(packGcz(image), image);
+});
+
+test('GCZ: a different block size round-trips', async () => {
+  const image = makeImage(4);
+  await roundTrip(packGcz(image, { blockSize: 0x4000 }), image);
+});
+
+test('expandGcz ignores files that are not GCZ', async () => {
+  const path = join(tempDataDir, 'plain.gcz');
+  writeFileSync(path, makeImage(2));
+  assert.equal(await gcz.expandGcz(path), null);
+});
+
+test('expandGcz rejects a header that contradicts itself', async () => {
+  const image = makeImage(4);
+  const path = join(tempDataDir, 'bad-count.gcz');
+  writeFileSync(path, packGcz(image, { corrupt: { blocks: 99 } }));
+  const result = await gcz.expandGcz(path);
+  assert.match(result.error, /block count/);
+});
+
+test('isGczPath covers the extension and nothing else', () => {
+  assert.equal(gcz.isGczPath('C:/roms/Game.GCZ'), true);
+  assert.equal(gcz.isGczPath('/roms/Game.iso'), false);
+  assert.equal(gcz.isGczPath('/roms/Game.rvz'), false);
+});

--- a/server/test/rvz-codecs.test.js
+++ b/server/test/rvz-codecs.test.js
@@ -1,0 +1,295 @@
+// Tests for the bzip2 and LZMA/LZMA2 decoders (server/src/hashing/bzip2.js and
+// lzma.js) and for reading a WIA/RVZ compressed with any of them.
+//
+// Node has no encoder for these, so the fixtures below were produced by Python's
+// `bz2` and `lzma` modules — an implementation with nothing in common with the
+// decoders under test — and are checked in base64 encoded. Each one decodes to
+// `fixtureIso()`, which is rebuilt here in JavaScript, so the comparison is
+// against data this file computes rather than against another blob.
+//
+// The three .rvz fixtures are complete files: header, both tables and the group
+// payload, every one of them compressed with the disc's own codec. Expanding one
+// therefore exercises the whole path, not just the codec.
+//
+// rvz.js writes into config.tempDir, so RA_DATA_DIR points at a throwaway
+// directory BEFORE the import.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tempDataDir = mkdtempSync(join(tmpdir(), 'ra-checker-codec-'));
+process.env.RA_DATA_DIR = tempDataDir;
+
+let bzip2, lzma, rvz;
+before(async () => {
+  bzip2 = await import('../src/hashing/bzip2.js');
+  lzma = await import('../src/hashing/lzma.js');
+  rvz = await import('../src/hashing/rvz.js');
+});
+after(() => { try { rmSync(tempDataDir, { recursive: true, force: true }); } catch { /* windows file locks */ } });
+
+const decode = (b64) => Buffer.from(b64.replace(/\s+/g, ''), 'base64');
+
+// The same generator the Python side used, so the expected bytes are computed
+// here instead of being another checked-in blob.
+function noise(size, seed) {
+  const buf = Buffer.alloc(size);
+  let s = seed >>> 0;
+  for (let i = 0; i < size; i++) {
+    s = (Math.imul(s, 1103515245) + 12345) >>> 0;
+    buf[i] = (s >>> 16) & 0xff;
+  }
+  return buf;
+}
+
+// A 32 KiB GameCube-shaped image: a header, a long run, repeating text and a
+// patch of noise — compressible enough to keep the fixtures small, varied enough
+// that literals, matches and repeated distances all get used.
+function fixtureIso() {
+  const iso = Buffer.alloc(0x8000);
+  noise(0x80, 7).copy(iso, 0);
+  iso.writeUInt32BE(0xc2339f3d, 0x1c);
+  iso.fill(0x41, 0x80, 0x4000);
+  Buffer.from('RAChecker RVZ codec fixture. '.repeat(200), 'latin1').copy(iso, 0x4000);
+  noise(0x400, 8).copy(iso, 0x7000);
+  return iso;
+}
+
+// bzip2 at level 1 (the smallest block size, so several blocks) — 1639 bytes
+const BZIP2_LEVEL1 = `
+  QlpoMTFBWSZTWYxSM5kACsF//////f//f//////////////////+///////3//////7/0AO+y7rdAOPXtJilRoTTCAbQGiaP
+  U0ZNpGE0wTCNHqYT9SaYJieo02gCYAGkyNoT0hpjRBoaB6m0mCZqNMANE9TTEZPSMmaJpgTeonpoCGTNEDRNoAmACYIwaTCY
+  I2phkCephMBpPQNCYBNDCYDQA0mCbUyaYAaaaIwmnqZoTDSDaAAEGJ5T0ho2UxMMgDoAJgIyehMCYmTAIwDQAmTBNMmZNGgT
+  IxPQ0m01PQYhkAGjUME0yYj00mTEwAACZME0wTDUyYPUE0aMAEAAAGgANAJgAABMDQJ6E0wABoAAAAAATADQnoEyYBoATAmN
+  AAJkyYA0GgTAAJhJVQjJkGQGmjQGQaaANANANNA0AGg0AaA0AAZqGgG1NGIaBoeoBkNBoDQAMg0000yNBoZA0aNAyaaaP4Ap
+  ZmQqw0ACPq1s6EHigOdDUP0ic9kY3eQtBLTr9K5uRyP4iKZwi/kHEScx7OVPUa6b9AUD0d0aE6CmOFGjs0VDAD9AMpTh1qoY
+  74d1oAX2IKXVGckDYKDKw2jduoYAUTA+Amu1gwknzhLj8BsnFcwLb69msRocQwt14I9oSJlWsXJ0pkcRfsu6PMHM22qVB2+E
+  DNsySAXIAQLggIE3AIFpepu2jrRdhgkscgIoLUHzxgAqwFErMfNhsxXMypA0XZoJSw+dV8OLiRVWKgiaa+dnqJgABQp97EAA
+  BAAPicc10F1+XRxgiCmQmswuje0eROjIBuIR9sk5hNKZnHr4E9Q3VFpaD+HBtw0YwwWnxF/vtzFyAFsTgewpw52HFSnATF3w
+  cbp4WW5i+ZiLcdJIhm0ZG0ddSSTuwAAOKAgWxzFSonHeIdoSSTJyu+QrcZ27fRgEGxvtkywJB/1iWIDDNR3Lk4BWH28omoFA
+  3Oe+Fr19rVv/CPM9oAJjBdcM3CRj1gCSFGTHuq3Yu01J1N6Y9R9g2/zyF56uGdHx3yrlBR0YkgFHMwCBf6dn/dYaVDve9kah
+  BX59hnwBAnzbu7pMPXcxsq+M7GEf2QCBTfgstevLa/4Ke2GamO9cLW1a12psJnJeL6rF5oKGnyUp4omQi+dIOEBzMxDvMzxg
+  ECbqFnAQK7AIFZ9j7blNgIF99fHgIEzAIFGgIFEAIE5NnAm3XhuLcAgTHyRTfrY+cevhs3ABAst5WWiasntHDkk81AIE42iA
+  +0pJU4BAmDZhm1u7rnUeRL6thp7NvufFbil7llXJrr+2ogIFhL5YJyD1FJeIPD6a6AIE2AIFXrFsq/b5+FmnvVtNjAQLQy86
+  xvTIBApaBfnO+3fJ7uMpLrp3lpawECk2nbfec9LD2dr3xW4yUiwGFfpOPSMNvdSQ1ecStIg+qGtlOvs1K41qBpNwredKN9fz
+  LM4X/uVIf5gEvVAXlZGNYZLduDmdoS83RNve+zLqfyIJ255sxZ/iT1+eLLm8MS5MY2qfnRdrKdOCnYOOEu7lAz0kYvM/bW2T
+  TK/Gt5MbNF2JjEHlodCzHf08PZKLedUUyk5f4bCmbkn/BXlobKqRtI1ArOsi7pa86W2eRAb/8CeYM/1LRSo0kNSorJ6m7Y5H
+  knwdjgMDEk/Tx8v2VSNjxQHqaGipmjsrLBOG+GcaiA50ijD0/UD3im7pXIr6r4861PDZjIhkGOozN3xxZlPtJybPov92ESJP
+  sk7Qd0OngoNJ1BHkTy3JdlD9KXfoFdTWVIhnmmJNL7qKEwEpPRnE64gZkZez0grAKWL9LvUz0UPB4fLg+RAlYJeDkw9MBgVG
+  NH4gIGbWJo1XAocI/aNKImnY92vBypZs4rS/fuXT/UavlqkQYlcl9F9wY6SwJYC7HQmxJzrhPNdAWhIE8649WhkJtSxDAGB1
+  olxv0FgEl4aIaFRLXvsipB6jmMPXO+8WkvFXi3Eb8xODGKNN9SMp20P9/h3vcqTAeL6DI0D2OMX2EHPL1HgZei9ni179mdSc
+  dvRrHwJYPfZCKQAC0dQEekZRIFS2o4/KJ9lUwH4ub6dLBQFsXyBb40o6D9AKYKYi1Q6Ec7deG4dmAnD/B/mSCCpdWEOnRpeW
+  FMZJhCOWIOOH3BBpCAIAYanzwhCEJFgEJVtgtmejDrXytjuDpOo6NnzH7F2BdyRThQkIxSM5kA==`;
+
+// raw LZMA1 with lc=0 lp=0 pb=0 — 1273 bytes
+const LZMA1_LC0LP0PB0 = `
+  ADYUQSi4n/xa5zVo89khgbAfBrrUv43cAD9Q0nyQAyRotshLZ5Yd8CA1hMumClln/iSOBpW0Xrrzf5hLzITRffKYHmxO6eJ4
+  rU/mFLiXRBxCkWubNldORsJLResxOfvY0VxwSJQdDhUycuSYWjykWrv8dlCQWR3KwvsCBGsCOj/pjTLqDR4N94Pb07KEPwjx
+  FTwQalf31SpyyxoQLI7chkZADsUeL3kFvIXkxlVnA/iWfWg8VuJPOewKTgAYaeD1iND5IAsTaC1AL+Eef+IHpK5YTeNgg9CG
+  HHXZz1psKoI3c13KjOtseQhJS6stUxK/ydNg0LLzJT5VnwS9TWtUh53ICXk5g+xuNqbKnFNa9o0RWIFwdSR2zWJveo/NY+WH
+  tuMu/8SictKoSZFiSWCmAoo92wo9zIyenEkpWmOnTLxtJnHyhnbSdhDaBS2Q0tR/L85ty5d9i8C7L9u/pksvJ35YxWE0RBD7
+  phfhtUprm1jLcDh0yJyANDogEcltp3PDbVMk3K+T4QlpW+z+PMzyEesA2e+ytCc/Dqm/ukBKkRy9X3+y8LCi00VI+SW/wpND
+  cRMNp4p9QL/OCEbyNn/qNIfNpz0/cD/8qRNrQW164Oza24OVvVn7lXwoYLAJ7lGc1EfC2NTFdswyWDkJ8oRUK9ZD83y+gvpw
+  hCAlVcdIFNDf3N1JvoS9vBGCn+NikW1XbvkyvyGe1T52xgw2LuAsksX/E2/53PXpUUvQgUVhybSjm7o2izGnkTOiOs+3Dj4n
+  m4nmctAASnCiAO2uQ4HKUvNeWMA4O5GG6CvWmdrU0UVakw/6zaoU0E0wQwjixngHV/ZoIypMArQWVL+5E4HFrfDH+bkpwPHO
+  8T/llYV695536B/5o2EkQETcCMVUYgLr3Vo44rBUO1k0HCLl0ujJnW7kDH3eak/JD+xYWcmeA8/ux4Cvb1PAEyKd0dTj8IBU
+  yHh5zDLUkRgvCfLaZbUwekXx1GEQs1yU2Ww6uG+hMgnmbdr0AkdqceIsmOCzk0Haqko5EQGfF3eBn4lcUIzbJia8nDmafjVS
+  Y8wQ4w2/xRdPaMH34aKdmMacootJ4Bkw2/I+TxEuMficapl+kFZShjMS99HvBB7FCdK94O0Aw6da2Nqd2+lYC8ocWbXfGHR3
+  QMHUDfFUAxAjPbjIUM/Q/7yn96BJOoNXb4L0vXuIxGsZEQ8Lbqir76I6L7F2vQ0rU0s4CIJtdrSXsuFsREnkdUgHxtZ/dT25
+  PdE3ch/S1/gpUkeSG9OIasvMrF0s5X1kSekgC+Tp+kiFtMiXN00ZKdvYNtr1D615fD12R5wtgoxAz9YgkvFN+b2gGHpyH3Cg
+  //sdZ/3EVfkxXOR6RqQU18On5eL2yI3oLgIXpYFiWOQS5No9P02VfSeZPIGWUdGDH8O02yeDGRldDBqKuZwy+m28wXO16qQX
+  qVge6BAC01bJnqJUzONRLHvIsTPGI4jMdvqu4l1gXrbAZsD2HFCATLkObVBIxC6knNPBuDoZG7oBp/qSF+pGQrA4DgHefdo8
+  CKXxasu5AXB90zk5xJGKVyI09cFybngewTYzaE6bt5I688V0xWGUjhG/0EoF3FgOv/Q5p2w1O0hHFvdauLC1VpuXcJiCy6cj
+  eWykrBGnv7HySADKudcmst1CVVPhZ72IOgjuhybISxQQRj4SdOC+f7ajD3///PdQAA==`;
+
+// raw LZMA1 with lc=0 lp=4 pb=0 — 1267 bytes
+const LZMA1_LC0LP4PB0 = `
+  ADYUJ+pmUgF280uiYRsFc5ZYI+98uF6WW20/BIe8iQp87/fXgMLj4hud17VC4+MRe/6ikQuYmgNCYlL5Sssr6UYPTTvrQheP
+  txGxQXiDelRzv0lrAmVAEEc26hk5jheK9lMSwFCE2bErbon5mFpTNDdu0QkpIoeyJsrU/+cGUzje3PQ4p19eh2RFSG7Bi3x5
+  PH/PmxHXdBdTYJ5oFrEp/yXON+q0D/8Hr7gDhPAJGXDJbNlrv14VJO523YP4l/5P22j+S4t7UQPxKYAihp6wKRfrG+ja21JT
+  dMT55pHgS3sSFj3VCwtNg5B3kMMgiiIx/Df9p2dT2MQrikNPi+VrUGIqhaQFedfSgtINMKU8lMryaLBMCJKBA2xEUHD0fcZu
+  JiKfDQz/TVobrT62f1v24Sty3R2NkGR7FzvePvpOT29OML0H2hzQGmZ0u1G91yruzu/+MBpOKhRwYzs+PXdSzylYrR52el8b
+  9hiQkYZDaPw3IhEQXIPZ5tp6gggPZo96FSRmYJKVkF5GLyiF5oxpZFHthcO4vcQ67wU6DoUIj6vtjr0TA0lYMCTO4d3F21q3
+  CXNf5B8HFKXVAnGRU/AIpmtq7PHx5tA5aXaNlMSpLSvGP3thn/9PQjMh7fhgNa7IHJzFOSlKnNNKkl4LPDApDbqiQvBjOjiO
+  nkCosvzFtNYQmW1zUA0p9tpKDtPLcvgOLo97YqVH39sib5e2xVwmQsPJKbIVxkOR854SC+f49P6MgSfUvqJWcdzf8DNAUQ/V
+  gNipDj4mjC4aR+xIkUh/EoeQDmYO2VpMWbPjl7GHx2B2OndFeyZQalgJvy77ssmoS7uQI+150HQ1TM1CkPfjknx2GpxD41Kx
+  uNCSj2r93zYXXySUXPhx2NjTVs6QyS6EQxP4uvG0bBRP9LohuwPiE5E32nCyJZ5j/PqO6Vcegw/qNDL5X21O3CoA7HhzshQX
+  JcD/WIfL1Yg6GWk3nDYPoC/DlDel2SnEIpYaPL+f1ej7CAw0cHB2QwsjLbWtrQ25i9usyENN0ts48sVaH7IQ5JxbbUHzw6k2
+  2PuwpmFBesO6G+KR0KrE5F30UscmAHA8fRQtewgcUKmuEooAlL9ZxRlWSVaxSmrAQhu71y582hodJBjFp6xqee5y7KZurW7I
+  xuXfr9mCJv+NM5pzKcyNX0KTwZt7RaWCwAL2qKUe0RH0TJgCbJQPvRSh1G6kLpfzy2ehPumgiljFkRHYeU3FzBgkycORDeeN
+  pFkxynz7ldi8fgXbZPbxANXigd9QX7pjj+HFIUoDG5PCRcQVTK4Jo5XeFzDwdzoRS5TziL/0/6/+A8ndYO3pOIPtG/AIUknV
+  gr44c1eBH9Wf0x6WXIybt+UUd2yCeCi1ImFj8zpZRQIW9GmUtjZbQ8Fo4L4mSy7UtgWa1yrGQU9W+9QMDiwnd5T+yRTRwwKQ
+  QNdoQ6YyvtZ1qpz7Nx2l1VPuPg+W+sjnrVvxsQc/aobVcW1wwgiVq0+6USYm4bmwgdUjZcojwLzAAzlru71KMzixSnRh54aM
+  L8bKbiNUIodY3nQazc57EOjGuM1lsukGoYCrUrHYbZ3WrvFXRP2VjWvJ4tmoejh1bvu5q0kTLFtzEKCayonM7OTL3QHbRJpf
+  YEZBf5nOVknLFBdsse+ytCLTsiZoTHaw3Tz9QobnF0K7gnFsoP//+2kAAA==`;
+
+// raw LZMA2 at preset 9 — 1288 bytes
+const LZMA2_PRESET9 = `
+  4H//BQBdADYTiolXmHKZyF9D77aclfGVnsMnoF1rPQ8zIbWiKTptbMN5JaFwVm9imgN+1bF35QN//I8EATeD6PDzW8fu8l8c
+  QUvqOP41faSjiLRAT/lsDb4TbizVwKb2lRE+xfcK2i6W2uhCoeMiVmFpWGWuYynQ+mNGnGmDhmSTgLTggA4czYUYiYxI+JJ8
+  w3CK6qaCfdxomb+sRxZtZNfBvIuEZTJ2bxNZRguEW4KQkpP7xbY5zVeM2bkLXUjXkfIKXL6n3h8LX6Ev4FXeHtqnVYEQBeoX
+  9/zo66nZyZcjtQ7SqaAfE6mPQyLetUoaMkZ5HSh7pCC/RnExe2v/uYSgD9Tj/d5VTDMAHkcJnPVHDZUj/C4FZkhD/QIhURSp
+  KPaujgbIdgDRG7tAiW5bKj1KXwsEWa3pBOOuunRbw2Nd15gHgoNsWGFuBHNISVBWGP9zKpNu8apTHCSRn9i+RZpes8d2q2bU
+  Jh9RbF/dx7W94FZH+xpw2EhHJtMNPBlDugBKcXoaxlTUN7dAOBCiXqEcTg0+URVHywy8HAfNxUYM5ihPVhtBf7sPUnXgjCf9
+  V277DJzIgToBKAcR6ry6czwouBoL3AJjka7XC6/NjarSTcCSe+dR2fottTMII/by7miNSosGOWn+VUpZxFHlz3EaNUsuIOc1
+  SizLU6XcZzprUKX+ZnTUnSN5/vEOmetpS15ePDDuUTAyrLFiQq62jY1Ug4BeX0kur5aHV1c1bqfi/QCWsjNUK2WUGxy5usfF
+  V6G66XdrMmlfEiB+1GRG54SPfRad+qY12W2AcZvZvJiuTOoRu+T9VoWP/eRf6c3ntFhLG04ta0CThUDVzxCpU2O3i8O7k/9m
+  4msts5oDvE9I70+wL+/yczwAzHLPYeq7OhcQTN/7N6NE6il/VxDft4XYuZa0cQA/cetme4AkGIA3jYgFwqfFWG0v3TV5qQIM
+  JmJpM7hXP/6aARLM2iha2OXtKK6QgTBm8+9/FSU59McoALF+9BE/h3mdmrQYYVXaePnof5YrhsnSD1xNR2Oq7LkM1EgjJyhD
+  pQ17WkASh5rm53MknVVAWI/ELrj1eR/OBWMoTpHYNAviqvhE7V9wy+rs/eAT6/TnpvXBELyOoL2Mr1ZPrOyrD6zlb5/zevul
+  TPcSzTVaalwy/XOxBSA2zNi/MXrziuuTEGZXUF1aBQzkweQDVsiTx6EXOKKxEY0d/F208AE5lEH+emIgu2kPwG+kedF+1LgE
+  qHryvQCc+WuRxWQB25y/2sjDl4oBG8zo5MEt1yDstkV1+UZMtaplzSPPWKavp36/UpfgWezTlK6bCNj7sNNuURg6pLLRKDLP
+  fn4hP4avZJZWyLZOGgI8VzLJU5sHEPEm7g9iU+EsW9jc56ApciA4L7MTLhGFuYRY0s3JiPWX1JLZ9No9kF2O4qjgKwqKVNvd
+  41Qdqjry/sZqgNbwN73X6AbD5R1BSlSHGC0KTyI2KyMeCahQdbVdOj0cTYPhz5VJRLsGNYNKPVj/+fqA/3OYImh4AlVjKfah
+  i2Lvsgp7E67R24v8VXTSEgFYFw5Hso4Oi5OKxKtRvHis/JrBSi5o3vhFVtSjUz5M5WS0kccOFusyoXDHAPD/DUVC3cA2ilI+
+  5QccY87YgzoDw9X2GCpoHqiysUVhFGC7qDCRLS45W9MXnK0o83AphV267nLhprn5v2/E5xlVPXiql4U22aAAAA==`;
+
+// raw LZMA2 over noise, so the encoder emits a stored chunk — 1028 bytes
+const LZMA2_STORED = `
+  AQP/RDJU7eUyDVHdLp3fBfkKoltCknDUalMv5ya+y9bZuvO6rpeWVnm5IZhLAXXu1/qqT4jIhgRe0bs6jCjkSdO+PsKcRyY7
+  2O1W2Zi436JruOaAe/ceFGYiCUDd8e5z/1yZs3N81WxHQar6jNlX+K7bDkaUN3Lce9/RUpIxIStWK7zlrE3bwcBN1FKffRPI
+  lv3a+kqguDWUn8rGIgC1Sc/EX7C903ASOKiMOUq8TeoetALyFUkp9ar7rvYGdeKlYr86bCEmzDip64kIBa47NjyYPohuS/72
+  tIs0ObWp3xgIswRyTl0mCgquhRVHahaF6ENFE82+bQ+r5hPnqLTmebk5dxi8kbhgVIg2uogJFq4bS9HsqbmvGIalBVhWrS6f
+  bOlKuOPauRJ/ElZOQaNzicxImWl6VvzpPWDA5Tit7mUZWzSpPE9g+IHkmynpT2Xu89RU5LmqjFvJr/3lxMxgoLkm70M/Cefr
+  VJW+o/kmJLWJhbyz3dCXRCIpdbB1IbopQ+Mx32MghMLwvncV6EDot4bzhzBf3lV+PmfensHFNdmwKbTTIKxxVUz3f9UutOnL
+  4bhvs7bt/uAYAfEHINAKh/eSLnnvxOR8YNeMPUSbX8mSaiqSWxTKQqWOZkMLWW8LEbRZKEiBFg8l91ekog2BiZKicSfFbPB9
+  36f1q/l5nT31J+s4ofo/55PvmGK+IYnj2Pf8yGwNqme+5FaWYkjM9ZuFnQJ0SZfaoFcH0BPxrq9dAoTPyQ8u2jncQVy/3jQM
+  /GQn3DmDVsJHxltEFpInxhhbv5NTibatSChuVYhSDVkPXEEgZ8O0dn3VThhCHy7/AZpmbYOUeLjkYJTZM72PtM0HoyV2H+nO
+  PBuXowyu+TIRVjGz0Eiu1AUbbUE7NvL1LfsFQ9+wLaN8Mu497ljBNz8o17+zvI7XofKw5BXXbvQo0R/SGo64zDSwCj9gNb/n
+  hKgS6KMJUZuzfRQZPLU7irUgqSue0MIgXC2l/9lcKRjYbZmGGEcw9zBTUzsl65CNzIFapOOPgnntQnXX0eY4pDEQJPGLjWHD
+  Eg4jn0qPp9dmjOyXYeMyr96HNB7B6yRiiShqgnT0HddRQz6eI7q3P3rYFluR5AiYKJSYLCCCJSrYTyWPSpScDOSNWpEnhPee
+  Af+PSeupPg7CAVpZZsRz1RUbDHKFhBY4w4Iwz84EocrylxG35koK56VlMv4NyUY5OCXWgp7ewzXnu3iwkVTrnUY4Uv/64ab9
+  yFjZcYqo1jA6BDwXDLfa2kfQ6ozniQ7u9HsMd6CESCcjdAUMV3pbkRNR94pHKpX/3Fg+vEm+QpX1+PV5UEwpPq9PbybrVww0
+  uaS9MchNK32d7CyWLgnAakBHxgA=`;
+
+// A complete RVZ of fixtureIso(), bzip2-compressed throughout — 2027 bytes
+const RVZ_BZIP2 = `
+  UlZaAQAAAAEAAAABAAAA3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAH6wAAAAAAAAAAAAAAAAAAAAAAAAAA
+  AAAAAQAAAAIAAAAAAACAAGxOdJITJSIuMaHNE74S7UJpZs4k/CPX2o0gl2HCM589worUAxNoKNRXHjxd7m5ewEqREV9dO1E+
+  wlOkFq1u5TiUEdAomqNM9cA0fFnK8ISV82EbC1Bo1ZgE+S63KZlVV3mZvnjAEGaHApnlf2zSNbz7j0Sd7uI74ezMjL/1v77C
+  AAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAeMAAAAMAAAAAEAAAAAAAAHvAAAAC8HAAAA
+  AAAAAEJaaDkxQVkmU1mMUjOZAArBf/////3//3///////////////////v//////9//////+/9ADvsu63QDj17SYpUaE0wgG
+  0Bomj1NGTaRhNMEwjR6mE/UmmCYnqNNoAmABpMjaE9IaY0QaGgeptJgmajTADRPU0xGT0jJmiaYE3qJ6aAhkzRA0TaAJgAmC
+  MGkwmCNqYZAnqYTAaT0DQmATQwmA0ANJgm1MmmAGmmiMJp6maEw0g2gABBieU9IaNlMTDIA6ACYCMnoTAmJkwCMA0AJkwTTJ
+  mTRoEyMT0NJtNT0GIZABo1DBNMmI9NJkxMAAAmTBNMEw1MmD1BNGjABAAABoADQCYAAATA0CehNMAAaAAAAAAEwA0J6BMmAa
+  AEwJjQACZMmANBoEwACYSVUIyZBkBpo0BkGmgDQDQDTQNABoNAGgNAAGahoBtTRiGgaHqAZDQaA0ADINNNNMjQaGQNGjQMmm
+  mj+AKWZkKsNAAj6tbOhB4oDnQ1D9InPZGN3kLQS06/Subkcj+IimcIv5BxEnMezlT1Gum/QFA9HdGhOgpjhRo7NFQwA/QDKU
+  4daqGO+HdaAF9iCl1RnJA2CgysNo3bqGAFEwPgJrtYMJJ84S4/AbJxXMC2+vZrEaHEMLdeCPaEiZVrFydKZHEX7LujzBzNtq
+  lQdvhAzbMkgFyAEC4ICBNwCBaXqbto60XYYJLHICKC1B88YAKsBRKzHzYbMVzMqQNF2aCUsPnVfDi4kVVioImmvnZ6iYAAUK
+  fexAAAQAD4nHNdBdfl0cYIgpkJrMLo3tHkToyAbiEfbJOYTSmZx6+BPUN1RaWg/hwbcNGMMFp8Rf77cxcgBbE4HsKcOdhxUp
+  wExd8HG6eFluYvmYi3HSSIZtGRtHXUkk7sAADigIFscxUqJx3iHaEkkycrvkK3Gdu30YBBsb7ZMsCQf9YliAwzUdy5OAVh9v
+  KJqBQNznvha9fa1b/wjzPaACYwXXDNwkY9YAkhRkx7qt2LtNSdTemPUfYNv88heerhnR8d8q5QUdGJIBRzMAgX+nZ/3WGlQ7
+  3vZGoQV+fYZ8AQJ827u6TD13MbKvjOxhH9kAgU34LLXry2v+CnthmpjvXC1tWtdqbCZyXi+qxeaChp8lKeKJkIvnSDhAczMQ
+  7zM8YBAm6hZwECuwCBWfY+25TYCBffXx4CBMwCBRoCBRACBOTZwJt14bi3AIEx8kU362PnHr4bNwAQLLeVlomrJ7Rw5JPNQC
+  BONogPtKSVOAQJg2YZtbu651HkS+rYaezb7nxW4pe5ZVya6/tqICBYS+WCcg9RSXiDw+mugCBNgCBV6xbKv2+fhZp71bTYwE
+  C0MvOsb0yAQKWgX5zvt3ye7jKS66d5aWsBApNp233nPSw9na98VuMlIsBhX6Tj0jDb3UkNXnErSIPqhrZTr7NSuNagaTcK3n
+  SjfX8yzOF/7lSH+YBL1QF5WRjWGS3bg5naEvN0Tb3vsy6n8iCduebMWf4k9fniy5vDEuTGNqn50XaynTgp2DjhLu5QM9JGLz
+  P21tk0yvxreTGzRdiYxB5aHQsx39PD2Si3nVFMpOX+Gwpm5J/wV5aGyqkbSNQKzrIu6WvOltnkQG//AnmDP9S0UqNJDUqKye
+  pu2OR5J8HY4DAxJP08fL9lUjY8UB6mhoqZo7KywThvhnGogOdIow9P1A94pu6VyK+q+POtTw2YyIZBjqMzd8cWZT7Scmz6L/
+  dhEiT7JO0HdDp4KDSdQR5E8tyXZQ/Sl36BXU1lSIZ5piTS+6ihMBKT0ZxOuIGZGXs9IKwCli/S71M9FDweHy4PkQJWCXg5MP
+  TAYFRjR+ICBm1iaNVwKHCP2jSiJp2PdrwcqWbOK0v37l0/1Gr5apEGJXJfRfcGOksCWAux0JsSc64TzXQFoSBPOuPVoZCbUs
+  QwBgdaJcb9BYBJeGiGhUS177IqQeo5jD1zvvFpLxV4txG/MTgxijTfUjKdtD/f4d73KkwHi+gyNA9jjF9hBzy9R4GXovZ4te
+  /ZnUnHb0ax8CWD32QikAAtHUBHpGUSBUtqOPyifZVMB+Lm+nSwUBbF8gW+NKOg/QCmCmItUOhHO3XhuHZgJw/wf5kggqXVhD
+  p0aXlhTGSYQjliDjh9wQaQgCAGGp88IQhCRYBCVbYLZnow618rY7g6TqOjZ8x+xdgXckU4UJCMUjOZAAQlpoOTFBWSZTWVRU
+  hAsAAAFAwHgAAADAACAAMMAEk0xRtBOUdwu5IpwoSCoqQgWAQlpoOTFBWSZTWTaJPj8AAALFQEEAACAAgEAAIAAhg0GaDRMj
+  xxdyRThQkDaJPj8=`;
+
+// A complete RVZ of fixtureIso(), lzma-compressed throughout — 1619 bytes
+const RVZ_LZMA = `
+  UlZaAQAAAAEAAAABAAAA3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAGUwAAAAAAAAAAAAAAAAAAAAAAAAAA
+  AAAAAQAAAAMAAAAAAACAAGxOdJITJSIuMaHNE74S7UJpZs4k/CPX2o0gl2HCM589worUAxNoKNRXHjxd7m5ewEqREV9dO1E+
+  wlOkFq1u5TiUEdAomqNM9cA0fFnK8ISV82EbC1Bo1ZgE+S63KZlVV3mZvnjAEGaHApnlf2zSNbz7j0Sd7uI74ezMjL/1v77C
+  AAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAYsAAAAEwAAAAEAAAAAAAAGQAAAABMHXQAA
+  EAAAAAA2E4qJV5hymchfQ++2nJXxlZ7DJ6Bdaz0PMyG1oik6bWzDeSWhcFZvYpoDftWxd+UDf/yPBAE3g+jw81vH7vJfHEFL
+  6jj+NX2ko4i0QE/5bA2+E24s1cCm9pURPsX3CtoultroQqHjIlZhaVhlrmMp0PpjRpxpg4Zkk4C04IAOHM2FGImMSPiSfMNw
+  iuqmgn3caJm/rEcWbWTXwbyLhGUydm8TWUYLhFuCkJKT+8W2Oc1XjNm5C11I15HyCly+p94fC1+hL+BV3h7ap1WBEAXqF/f8
+  6Oup2cmXI7UO0qmgHxOpj0Mi3rVKGjJGeR0oe6Qgv0ZxMXtr/7mEoA/U4/3eVUwzAB5HCZz1Rw2VI/wuBWZIQ/0CIVEUqSj2
+  ro4GyHYA0Ru7QIluWyo9Sl8LBFmt6QTjrrp0W8NjXdeYB4KDbFhhbgRzSElQVhj/cyqTbvGqUxwkkZ/YvkWaXrPHdqtm1CYf
+  UWxf3ce1veBWR/sacNhIRybTDTwZQ7oASnF6GsZU1De3QDgQol6hHE4NPlEVR8sMvBwHzcVGDOYoT1YbQX+7D1J14Iwn/Vdu
+  +wycyIE6ASgHEeq8unM8KLgaC9wCY5Gu1wuvzY2q0k3AknvnUdn6LbUzCCP28u5ojUqLBjlp/lVKWcRR5c9xGjVLLiDnNUos
+  y1Ol3Gc6a1Cl/mZ01J0jef7xDpnraUteXjww7lEwMqyxYkKuto2NVIOAXl9JLq+Wh1dXNW6n4v0AlrIzVCtllBscubrHxVeh
+  uul3azJpXxIgftRkRueEj30WnfqmNdltgHGb2byYrkzqEbvk/VaFj/3kX+nN57RYSxtOLWtAk4VA1c8QqVNjt4vDu5P/ZuJr
+  LbOaA7xPSO9PsC/v8nM8AMxyz2HquzoXEEzf+zejROopf1cQ37eF2LmWtHEAP3HrZnuAJBiAN42IBcKnxVhtL901eakCDCZi
+  aTO4Vz/+mgESzNooWtjl7SiukIEwZvPvfxUlOfTHKACxfvQRP4d5nZq0GGFV2nj56H+WK4bJ0g9cTUdjquy5DNRIIycoQ6UN
+  e1pAEoea5udzJJ1VQFiPxC649XkfzgVjKE6R2DQL4qr4RO1fcMvq7P3gE+v056b1wRC8jqC9jK9WT6zsqw+s5W+f83r7pUz3
+  Es01WmpcMv1zsQUgNszYvzF684rrkxBmV1BdWgUM5MHkA1bIk8ehFziisRGNHfxdtPABOZRB/npiILtpD8BvpHnRftS4BKh6
+  8r0AnPlrkcVkAducv9rIw5eKARvM6OTBLdcg7LZFdflGTLWqZc0jz1imr6d+v1KX4Fns05SumwjY+7DTblEYOqSy0Sgyz35+
+  IT+Gr2SWVsi2ThoCPFcyyVObBxDxJu4PYlPhLFvY3OegKXIgOC+zEy4RhbmEWNLNyYj1l9SS2fTaPZBdjuKo4CsKilTb3eNU
+  Hao68v7GaoDW8De91+gGw+UdQUpUhxgtCk8iNisjHgmoUHW1XTo9HE2D4c+VSUS7BjWDSj1Y//n6gP9zmCJoeAJVYyn2oYti
+  77IKexOu0duL/FV00hIBWBcOR7KODouTisSrUbx4rPyawUouaN74RVbUo1M+TOVktJHHDhbrMqFwxwDw/w1FQt3ANopSPuUH
+  HGPO2IM6A8PV9hgqaB6osrFFYRRgu6gwkS0uOVvTF5ytKPNwKYVduu5y4aa5+b9vxOcZVT14qpeFWHty///9xvAAAAAAAGoe
+  e5Pu9GPm/p8u+//+32AAAAAAaBCvtsAvqlJD92q///6LeAA=`;
+
+// A complete RVZ of fixtureIso(), lzma2-compressed throughout — 1620 bytes
+const RVZ_LZMA2 = `
+  UlZaAQAAAAEAAAABAAAA3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAGVAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  AAAAAQAAAAQAAAAAAACAAGxOdJITJSIuMaHNE74S7UJpZs4k/CPX2o0gl2HCM589worUAxNoKNRXHjxd7m5ewEqREV9dO1E+
+  wlOkFq1u5TiUEdAomqNM9cA0fFnK8ISV82EbC1Bo1ZgE+S63KZlVV3mZvnjAEGaHApnlf2zSNbz7j0Sd7uI74ezMjL/1v77C
+  AAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAYsAAAAFQAAAAEAAAAAAAAGRAAAABAHGAAA
+  AAAAAOB//wUAXQA2E4qJV5hymchfQ++2nJXxlZ7DJ6Bdaz0PMyG1oik6bWzDeSWhcFZvYpoDftWxd+UDf/yPBAE3g+jw81vH
+  7vJfHEFL6jj+NX2ko4i0QE/5bA2+E24s1cCm9pURPsX3CtoultroQqHjIlZhaVhlrmMp0PpjRpxpg4Zkk4C04IAOHM2FGImM
+  SPiSfMNwiuqmgn3caJm/rEcWbWTXwbyLhGUydm8TWUYLhFuCkJKT+8W2Oc1XjNm5C11I15HyCly+p94fC1+hL+BV3h7ap1WB
+  EAXqF/f86Oup2cmXI7UO0qmgHxOpj0Mi3rVKGjJGeR0oe6Qgv0ZxMXtr/7mEoA/U4/3eVUwzAB5HCZz1Rw2VI/wuBWZIQ/0C
+  IVEUqSj2ro4GyHYA0Ru7QIluWyo9Sl8LBFmt6QTjrrp0W8NjXdeYB4KDbFhhbgRzSElQVhj/cyqTbvGqUxwkkZ/YvkWaXrPH
+  dqtm1CYfUWxf3ce1veBWR/sacNhIRybTDTwZQ7oASnF6GsZU1De3QDgQol6hHE4NPlEVR8sMvBwHzcVGDOYoT1YbQX+7D1J1
+  4Iwn/Vdu+wycyIE6ASgHEeq8unM8KLgaC9wCY5Gu1wuvzY2q0k3AknvnUdn6LbUzCCP28u5ojUqLBjlp/lVKWcRR5c9xGjVL
+  LiDnNUosy1Ol3Gc6a1Cl/mZ01J0jef7xDpnraUteXjww7lEwMqyxYkKuto2NVIOAXl9JLq+Wh1dXNW6n4v0AlrIzVCtllBsc
+  ubrHxVehuul3azJpXxIgftRkRueEj30WnfqmNdltgHGb2byYrkzqEbvk/VaFj/3kX+nN57RYSxtOLWtAk4VA1c8QqVNjt4vD
+  u5P/ZuJrLbOaA7xPSO9PsC/v8nM8AMxyz2HquzoXEEzf+zejROopf1cQ37eF2LmWtHEAP3HrZnuAJBiAN42IBcKnxVhtL901
+  eakCDCZiaTO4Vz/+mgESzNooWtjl7SiukIEwZvPvfxUlOfTHKACxfvQRP4d5nZq0GGFV2nj56H+WK4bJ0g9cTUdjquy5DNRI
+  IycoQ6UNe1pAEoea5udzJJ1VQFiPxC649XkfzgVjKE6R2DQL4qr4RO1fcMvq7P3gE+v056b1wRC8jqC9jK9WT6zsqw+s5W+f
+  83r7pUz3Es01WmpcMv1zsQUgNszYvzF684rrkxBmV1BdWgUM5MHkA1bIk8ehFziisRGNHfxdtPABOZRB/npiILtpD8BvpHnR
+  ftS4BKh68r0AnPlrkcVkAducv9rIw5eKARvM6OTBLdcg7LZFdflGTLWqZc0jz1imr6d+v1KX4Fns05SumwjY+7DTblEYOqSy
+  0Sgyz35+IT+Gr2SWVsi2ThoCPFcyyVObBxDxJu4PYlPhLFvY3OegKXIgOC+zEy4RhbmEWNLNyYj1l9SS2fTaPZBdjuKo4CsK
+  ilTb3eNUHao68v7GaoDW8De91+gGw+UdQUpUhxgtCk8iNisjHgmoUHW1XTo9HE2D4c+VSUS7BjWDSj1Y//n6gP9zmCJoeAJV
+  Yyn2oYti77IKexOu0duL/FV00hIBWBcOR7KODouTisSrUbx4rPyawUouaN74RVbUo1M+TOVktJHHDhbrMqFwxwDw/w1FQt3A
+  NopSPuUHHGPO2IM6A8PV9hgqaB6osrFFYRRgu6gwkS0uOVvTF5ytKPNwKYVduu5y4aa5+b9vxOcZVT14qpeFNtmgAADgABcA
+  DV0AAGoee5Pu9GPm/H7AAAAAAAABAAsAAABJgAAFCAAAAAAA`;
+
+
+test('bzip2: a multi-block stream decodes byte for byte', () => {
+  assert.ok(bzip2.bzip2Decompress(decode(BZIP2_LEVEL1), 0x8000).equals(fixtureIso()));
+});
+
+test('bzip2: a corrupt stream is rejected, not mis-decoded', () => {
+  const broken = decode(BZIP2_LEVEL1);
+  broken[3] = 0x30; // block size digit 0
+  assert.throws(() => bzip2.bzip2Decompress(broken, 0x8000), /bzip2/);
+});
+
+test('LZMA: raw streams decode byte for byte across property settings', () => {
+  const expected = fixtureIso();
+  assert.ok(lzma.lzma1Decompress(decode(LZMA1_LC0LP0PB0), 0, 0x8000).equals(expected));
+  assert.ok(lzma.lzma1Decompress(decode(LZMA1_LC0LP4PB0), 36, 0x8000).equals(expected));
+});
+
+test('LZMA2: a compressed stream decodes byte for byte', () => {
+  assert.ok(lzma.lzma2Decompress(decode(LZMA2_PRESET9), 0x8000).equals(fixtureIso()));
+});
+
+test('LZMA2: a stored chunk decodes byte for byte', () => {
+  assert.ok(lzma.lzma2Decompress(decode(LZMA2_STORED), 0x8000).equals(noise(1024, 21)));
+});
+
+test('LZMA: an out-of-range properties byte is rejected', () => {
+  assert.throws(() => lzma.lzma1Decompress(decode(LZMA1_LC0LP0PB0), 225, 0x8000), /properties/);
+});
+
+// Expanding these covers the tables as well as the group payload: both are
+// compressed with the disc's codec, so a broken decoder cannot even get as far
+// as reading where the data is.
+for (const [name, fixture] of [['bzip2', RVZ_BZIP2], ['LZMA', RVZ_LZMA], ['LZMA2', RVZ_LZMA2]]) {
+  test(`RVZ: a ${name}-compressed image expands byte for byte`, async () => {
+    const path = join(tempDataDir, `codec-${name}.rvz`);
+    writeFileSync(path, decode(fixture));
+    const result = await rvz.expandRvz(path);
+    assert.equal(result?.error, undefined, `expandRvz failed: ${result?.error}`);
+    try {
+      assert.ok(readFileSync(result.path).equals(fixtureIso()), 'expanded image differs from the reference');
+    } finally {
+      await result.cleanup();
+    }
+  });
+}

--- a/server/test/rvz.test.js
+++ b/server/test/rvz.test.js
@@ -445,14 +445,15 @@ test('expandRvz ignores files that are not WIA/RVZ', async () => {
   assert.equal(await rvz.expandRvz(path), null);
 });
 
-test('expandRvz names the compression it cannot read', async () => {
+test('expandRvz reports a compression method it does not know', async () => {
+  // Every method the format documents is implemented, so this can only be a file
+  // from a newer Dolphin than the spec this was written against.
   const { file } = gameCubeFixture(NONE);
-  file.writeUInt32BE(4, 0x48 + 0x04); // claim LZMA2
-  const path = join(tempDataDir, 'lzma2.rvz');
+  file.writeUInt32BE(6, 0x48 + 0x04);
+  const path = join(tempDataDir, 'future-codec.rvz');
   writeFileSync(path, file);
   const result = await rvz.expandRvz(path);
-  assert.match(result.error, /LZMA2/);
-  assert.match(result.error, /Zstandard/);
+  assert.match(result.error, /compression type 6/);
 });
 
 test('isRvzPath covers both extensions and nothing else', () => {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker-web",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version + changelog. The footer version
 // chip opens a modal rendering CHANGELOG; package.json is kept in sync manually.
-export const APP_VERSION = '0.15.0';
+export const APP_VERSION = '0.16.0';
 
 // GitHub repository — linked from the header (GitHub icon in the "More" menu).
 export const REPO_URL = 'https://github.com/x3kim/RAChecker';
@@ -15,6 +15,15 @@ export interface Release { version: string; date: string; title?: { de: string; 
 
 // Newest first. Dates are ISO (YYYY-MM-DD).
 export const CHANGELOG: Release[] = [
+  {
+    version: '0.16.0',
+    date: '2026-08-18',
+    title: { de: 'Alle GameCube- und Wii-Container', en: 'Every GameCube and Wii container' },
+    changes: [
+      { type: 'feature', de: 'RVZ- und WIA-Images werden jetzt in jedem Kompressionsverfahren gelesen, das Dolphin anbietet. Bisher lief nur Zstandard; bei bzip2, LZMA oder LZMA2 kam der Hinweis zurück, die Datei neu zu komprimieren. Das ist nicht mehr nötig.', en: 'RVZ and WIA images are read in every compression method Dolphin offers. Only Zstandard worked before; bzip2, LZMA and LZMA2 came back asking you to re-compress the file. That is no longer necessary.' },
+      { type: 'feature', de: 'Das ältere GCZ-Format von Dolphin wird jetzt ebenfalls gehasht. RAHasher las bei einer .gcz den Container-Kopf, als wäre er die Disc, und meldete „Not a Gamecube disc“ — solche Dateien ließen sich gar nicht zuordnen. Sie werden nun wie RVZ und CSO kurz ausgepackt und danach wieder aufgeräumt.', en: 'The older GCZ format Dolphin writes is hashed as well now. RAHasher read a .gcz container header as if it were the disc and reported „Not a Gamecube disc“, so those files could not be matched at all. They are now expanded for the moment it takes to hash, like RVZ and CSO.' },
+    ],
+  },
   {
     version: '0.15.0',
     date: '2026-08-18',


### PR DESCRIPTION
Follow-up to #29. Two things it left open, and an audit of the containers next
to RVZ.

## Every WIA/RVZ compression method, not just Zstandard

0.15.0 read Zstandard only — Dolphin's default, but not the only thing it
writes. `bzip2`, `LZMA` and `LZMA2` came back with a message asking the user to
re-compress the file, which is less a fix than an apology. All three are
implemented, so the format is now covered end to end: none, Purge, bzip2, LZMA,
LZMA2, Zstandard.

**Written out rather than pulled in**, on purpose:

- the native packages (`lzma-native`, `@mongodb-js/zstd`) would each need
  rebuilding against Electron's ABI, and `npm ci` would have to compile in CI —
  which today has no native dependencies at all, on any of the four jobs;
- the pure-JavaScript LZMA packages only speak the `.lzma alone` container.
  WIA/RVZ stores a **raw** stream: no header, no framing, with lc/lp/pb sitting
  in `wia_disc_t.compr_data` instead.

So: `server/src/hashing/bzip2.js` (Huffman → move-to-front → inverse
Burrows-Wheeler → run-length) and `server/src/hashing/lzma.js` (the range coder
and match model from `LzmaSpec.cpp`, plus the LZMA2 chunk layer with its state,
property and dictionary resets). No new dependency; `package.json` is untouched
apart from the version and one script.

One wrinkle worth knowing about: raw LZMA1 stores neither a length nor, in
Dolphin's writer, an end-of-stream marker. `decompressStream` therefore takes
the largest output a group can possibly need — exact for raw data, and for
partition data bounded by the geometry (at most 47 hashes in a sector's hash
block, at most 64 sectors to an exception list).

## GCZ was broken the same way RVZ was

Checked with the real RAHasher: hand it a `.gcz` and it reads the container
header as though it were the disc — `Not a Gamecube disc`. Fixed the same way,
and it is the easiest of the three: deflate blocks and a table of offsets, much
like a little-endian CSO.

## WBFS is broken too, and is *not* fixed here

Same check, one payload presented twice: as `.iso` RAHasher reaches
`Hashing 128 byte main header`, as `.wbfs` it stops at
`Not a supported Wii file`. It never looks inside the container.

Left for its own branch on purpose — reconstructing a WBFS needs disc geometry
(how many logical sectors a disc is taken to have) that I cannot check against
anything without a real dump. Documented as unsupported in both READMEs so it
is not a silent surprise.

## A diagnostic for the next report of this kind

```bash
npm run rvz:info -- "D:\ROMs\GameCube"
```

Prints the compression, chunk size, disc type and size of every `.rvz`/`.wia`
under a path, reading only the first 92 bytes of each file — quick even over a
network share. The compression method is the first thing worth knowing about a
"this will not hash" report and is not visible anywhere else without opening
the file in Dolphin.

## Verification

1. **87 codec vectors from Python's `bz2` and `lzma`** — implementations with
   nothing in common with these decoders. bzip2 at levels 1/6/9 over eight
   payload shapes including a multi-block one; raw LZMA1 across six lc/lp/pb
   settings; raw LZMA2 at three presets. Every one byte-exact.
2. **Three complete `.rvz` files checked in** (`server/test/rvz-codecs.test.js`),
   bzip2/LZMA/LZMA2 compressed *throughout* — header, both tables and the group
   payload. Expanding one exercises the whole path, not just the codec, and they
   decode to an image the test rebuilds itself rather than to another blob.
3. **GCZ round-trips** (`server/test/gcz.test.js`), and RAHasher returns the
   same hash for a synthetic GameCube image whether handed the `.iso` or the
   `.gcz` through `hashTarget`.

129/129 tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand compressed GameCube and Wii image support by decoding every documented RVZ/WIA codec, adding GCZ expansion, and providing metadata diagnostics.

New Features:
- Support hashing RVZ and WIA images using all documented Dolphin compression methods.
- Add GCZ image expansion so compressed GameCube and Wii images can be hashed.
- Add an rvz:info diagnostic command for inspecting RVZ/WIA metadata under a path.

Bug Fixes:
- Fix compressed GameCube images being interpreted as raw discs instead of expanded before hashing.
- Replace unsupported-compression messaging for documented RVZ/WIA codecs with actual decoding support.

Build:
- Add the rvz:info npm script and bump project package versions to 0.16.0.

Documentation:
- Document support for all WIA/RVZ compression methods and GCZ images, and clarify that WBFS remains unsupported.

Tests:
- Add codec coverage for bzip2, raw LZMA/LZMA2, and complete RVZ expansion.
- Add GCZ round-trip and validation tests.