### PR TITLE
WBFS, GameCube CISO and NKit detection (desktop 0.17.0)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -253,14 +253,18 @@ Der automatische Download geht nur unter Windows. Unter Linux/macOS RAHasher sel
 
 **Android** braucht keinen RAHasher — die Disc-Regeln sind direkt in der App umgesetzt.
 
-**Komprimierte Container, die RAHasher nicht öffnen kann** — `.cso`/`.zso` (PSP, PS2) sowie
-Dolphins `.rvz`/`.wia` und das ältere `.gcz` (GameCube, Wii) — werden für die Dauer des
-Hashens in eine echte `.iso` im Temp-Ordner ausgepackt und danach wieder entfernt. Der Hash
-ist derselbe wie beim unkomprimierten Image. Alle Kompressionsverfahren, die WIA/RVZ kennt,
-werden gelesen: none, Purge, bzip2, LZMA, LZMA2 und Zstandard.
+**Container, die RAHasher nicht öffnen kann** — `.cso`/`.zso` (PSP, PS2), Dolphins
+`.rvz`/`.wia` und das ältere `.gcz`, das `.wbfs` der USB-Loader sowie die GameCube-/Wii-Variante
+von `.ciso` — werden für die Dauer des Hashens in eine echte `.iso` im Temp-Ordner ausgepackt
+und danach wieder entfernt. Der Hash ist derselbe wie beim unkomprimierten Image. Alle
+Kompressionsverfahren, die WIA/RVZ kennt, werden gelesen: none, Purge, bzip2, LZMA, LZMA2 und
+Zstandard.
 
-`.wbfs` wird **noch nicht** unterstützt. RAHasher liest den Container-Header, als wäre er die
-Disc, und weist die Datei ab — solche Images können vorerst gar nicht zugeordnet werden.
+**NKit-Images werden benannt, nicht gehasht.** NKit entfernt das Padding, mit dem eine Disc
+gemastert wurde — der Hash kann also nie passen. Die Datei behält aber die Endung `.iso` und
+einen echten Disc-Header, und RAHasher hasht sie klaglos. RAChecker sagt jetzt, was die Datei
+ist, statt ein voll unterstütztes Spiel als „kein Treffer" zu melden. Mit dem NKit-Tool in ein
+echtes `.iso` zurückwandeln und erneut scannen.
 
 Was in einem Disc-Image wirklich steckt — Kompression, Chunk-Größe, Disc-Typ — zeigt
 `npm run rvz:info -- "D:\ROMs\GameCube"`. Das Script liest nur die ersten 92 Byte pro Datei

--- a/README.md
+++ b/README.md
@@ -251,14 +251,17 @@ The automatic download is Windows-only. On Linux/macOS, build RAHasher yourself 
 
 **Android** doesn't need RAHasher — the disc rules are implemented natively in the app.
 
-**Compressed containers RAHasher cannot open** — `.cso`/`.zso` (PSP, PS2) and Dolphin's
-`.rvz`/`.wia` and older `.gcz` (GameCube, Wii) — are expanded into a plain `.iso` in the temp
-folder for the moment it takes to hash, then removed again. The hash is the one the raw image
-produces. Every compression method WIA/RVZ defines is read: none, Purge, bzip2, LZMA, LZMA2
-and Zstandard.
+**Containers RAHasher cannot open** — `.cso`/`.zso` (PSP, PS2), Dolphin's `.rvz`/`.wia` and
+older `.gcz`, the `.wbfs` USB loaders keep games in, and the GameCube/Wii flavour of `.ciso` —
+are turned back into a plain `.iso` in the temp folder for the moment it takes to hash, then
+removed again. The hash is the one the raw image produces. Every compression method WIA/RVZ
+defines is read: none, Purge, bzip2, LZMA, LZMA2 and Zstandard.
 
-`.wbfs` is **not** supported yet. RAHasher reads the container header as if it were the disc
-and rejects the file, so those images cannot be matched at all for now.
+**NKit images are named, not hashed.** NKit strips the padding a disc was mastered with, so its
+hash can never match RetroAchievements — but the file keeps the `.iso` extension and a genuine
+disc header, and RAHasher hashes it without complaint. RAChecker says what the file is instead
+of reporting a fully supported game as "no match". Convert it back to a full `.iso` with the
+NKit tool and scan it again.
 
 To see what a disc image actually holds — its compression, chunk size and disc type —
 run `npm run rvz:info -- "D:\ROMs\GameCube"`. It reads only the first 92 bytes of each file,

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,9 +16,11 @@ Tab **Hash-DB** → **Synchronisieren** (oder **Komplett neu** für ein vollstä
 Nur nötig für Disc-Systeme (PS1/PS2/PSP/Saturn/Dreamcast/…) und `.chd`.
 Tab **Einstellungen** → **RAHasher herunterladen.** Cartridge-Systeme funktionieren ohne.
 
-Komprimierte Container, die RAHasher nicht öffnet — `.cso`/`.zso` sowie Dolphins `.rvz`/`.wia`
-und `.gcz` — packt RAChecker zum Hashen kurz in eine echte `.iso` aus und räumt sie danach
-wieder weg; alle Kompressionsverfahren von WIA/RVZ werden gelesen. `.wbfs` geht noch nicht.
+Container, die RAHasher nicht öffnet — `.cso`/`.zso`, Dolphins `.rvz`/`.wia` und `.gcz`, das
+`.wbfs` der USB-Loader und die GameCube-/Wii-Variante von `.ciso` — packt RAChecker zum Hashen
+kurz in eine echte `.iso` aus und räumt sie danach wieder weg; alle Kompressionsverfahren von
+WIA/RVZ werden gelesen. NKit-Images (`NKIT`-Kennung, meist `.nkit.iso`) werden als solche
+gemeldet: sie lassen sich nicht hashen und müssen erst mit dem NKit-Tool zurückgewandelt werden.
 
 ## 3. Bibliothek scannen
 Tab **Scannen**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "description": "RetroAchievements ROM Compatibility Checker — scan your ROM library and find which games can earn achievements.",

--- a/server/src/consoles.js
+++ b/server/src/consoles.js
@@ -30,7 +30,7 @@ export const CONSOLES = [
   { id: 16, short: 'gc',    name: 'GameCube',                  method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.wia', '.gcm', '.gcz', '.ciso'] },
   { id: 17, short: 'jag',   name: 'Atari Jaguar',              method: 'file',     headerRule: null,      exts: ['.j64', '.jag', '.rom', '.abs', '.cof'] },
   { id: 18, short: 'ds',    name: 'Nintendo DS',               method: 'rahasher', headerRule: null,      exts: ['.nds', '.srl', '.ids'] },
-  { id: 19, short: 'wii',   name: 'Wii',                       method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.wia', '.wbfs', '.wad'] },
+  { id: 19, short: 'wii',   name: 'Wii',                       method: 'rahasher', headerRule: null,      exts: ['.iso', '.rvz', '.wia', '.wbfs', '.ciso', '.wad'] },
   { id: 21, short: 'ps2',   name: 'PlayStation 2',             method: 'rahasher', headerRule: null,      exts: ['.iso', '.chd', '.cue', '.bin', '.m3u', '.cso'] },
   { id: 23, short: 'mo2',   name: 'Magnavox Odyssey 2',        method: 'file',     headerRule: null,      exts: ['.bin'] },
   { id: 24, short: 'mini',  name: 'Pokemon Mini',              method: 'file',     headerRule: null,      exts: ['.min'] },

--- a/server/src/hashing/ciso-gc.js
+++ b/server/src/hashing/ciso-gc.js
@@ -1,0 +1,172 @@
+// GameCube/Wii CISO support.
+//
+// `.ciso` names two unrelated formats. PSP dumps use it for the block-index
+// layout cso.js reads; GameCube and Wii backup tools use it for this one, which
+// shares only the magic word. cso.js rejects anything that is not a PSP CSO, so
+// a file that falls through to here is either this format or not a CISO at all.
+//
+// RAHasher cannot open one — it reads the CISO header as if it were the disc and
+// reports "Not a Gamecube disc" — so it is turned back into a plain .iso, like
+// .rvz, .gcz and .wbfs.
+//
+// The layout is the simplest of the lot: a fixed 0x8000-byte header holding the
+// magic, the block size and one byte per block saying whether that block was
+// stored, then the stored blocks back to back. Blocks that were dropped were all
+// zeroes, and come back as zeroes.
+//
+//   0x0000  char  magic "CISO"
+//   0x0004  u32   block size, little endian (2 MiB is usual)
+//   0x0008  u8    presence map, one byte per block, non-zero = stored
+//   0x8000        the stored blocks, in order
+import { open, stat, unlink, statfs } from 'node:fs/promises';
+import { join, basename, extname } from 'node:path';
+import { config } from '../config.js';
+
+const HEADER_SIZE = 0x8000;
+const MAP_OFFSET = 8;
+const MAP_ENTRIES = HEADER_SIZE - MAP_OFFSET;
+const MAX_BLOCK_SIZE = 64 << 20;
+const COPY_CHUNK = 4 << 20;
+
+// The sizes a finished dump has, so a stored region that stops short of the end
+// of the disc is padded rather than truncated.
+const GAMECUBE_SIZE = 1459978240;
+const WII_SINGLE_LAYER_SIZE = 143432 * 0x8000;
+const WII_DUAL_LAYER_SIZE = 259740 * 0x8000;
+
+async function readExact(fh, size, position) {
+  const buf = Buffer.alloc(size);
+  let got = 0;
+  while (got < size) {
+    const { bytesRead } = await fh.read(buf, got, size - got, position + got);
+    if (bytesRead === 0) throw new Error(`file ends at ${position + got}, wanted ${position + size}`);
+    got += bytesRead;
+  }
+  return buf;
+}
+
+// Parse the header. Returns null when the file is not a GameCube/Wii CISO.
+async function readCisoIndex(fh, fileSize) {
+  const head = Buffer.alloc(HEADER_SIZE);
+  const { bytesRead } = await fh.read(head, 0, HEADER_SIZE, 0);
+  if (bytesRead < HEADER_SIZE) return null;
+  if (head.toString('latin1', 0, 4) !== 'CISO') return null;
+
+  // A block size outside what this format uses means the file is something else
+  // wearing the same magic — a malformed PSP CSO, most likely. Returning null
+  // leaves it to be hashed exactly as it was before, rather than failing it.
+  const blockSize = head.readUInt32LE(4);
+  if (blockSize < 0x8000 || blockSize > MAX_BLOCK_SIZE || (blockSize & (blockSize - 1)) !== 0) return null;
+  // The first block is always stored: it holds the disc header.
+  if (head[MAP_OFFSET] === 0) throw new Error('the first block is missing');
+
+  let stored = 0;
+  let lastStored = -1;
+  for (let i = 0; i < MAP_ENTRIES; i++) {
+    if (head[MAP_OFFSET + i] === 0) continue;
+    stored++;
+    lastStored = i;
+  }
+  if (HEADER_SIZE + stored * blockSize > fileSize) {
+    throw new Error('the presence map claims more blocks than the file holds');
+  }
+
+  return { head, blockSize, lastStored };
+}
+
+// Is there room in temp for the expanded image (plus 15% headroom)?
+async function tempHasRoom(bytes) {
+  try {
+    const fs = await statfs(config.tempDir);
+    return fs.bavail * fs.bsize >= bytes * 1.15;
+  } catch { return true; }
+}
+
+/**
+ * Expand a GameCube/Wii `.ciso` into a plain `.iso` in the temp folder.
+ *
+ * Returns { path, cleanup, size } on success, { error } when it cannot be read,
+ * or null when the file is not this format. `onProgress(done, total)` reports
+ * written bytes.
+ */
+export async function expandGameCubeCiso(filePath, { signal, onProgress } = {}) {
+  const fh = await open(filePath, 'r');
+  const fileSize = (await stat(filePath)).size;
+  let index;
+  try {
+    index = await readCisoIndex(fh, fileSize);
+  } catch (e) {
+    await fh.close();
+    return { error: `Could not read the CISO header: ${String(e.message).slice(0, 160)}` };
+  }
+  if (!index) {
+    await fh.close();
+    return null;
+  }
+
+  const { head, blockSize, lastStored } = index;
+  const covered = (lastStored + 1) * blockSize;
+
+  // A dump that ends before the disc does was scrubbed, not truncated: the rest
+  // was zeroes. Grow the image to the disc's real size so a hash rule reading
+  // near the end finds zeroes rather than the end of the file. Which size that
+  // is comes from the disc header, which sits in the first block.
+  const first = await readExact(fh, 0x20, HEADER_SIZE);
+  let standard = 0;
+  if (first.readUInt32BE(0x1c) === 0xc2339f3d) standard = GAMECUBE_SIZE;
+  else if (first.readUInt32BE(0x18) === 0x5d1c9ea3) {
+    standard = covered <= WII_SINGLE_LAYER_SIZE ? WII_SINGLE_LAYER_SIZE : WII_DUAL_LAYER_SIZE;
+  }
+  const isoSize = standard > covered ? standard : covered;
+
+  if (!(await tempHasRoom(isoSize))) {
+    await fh.close();
+    const gb = (isoSize / 1024 ** 3).toFixed(1);
+    return { error: `Not enough free space in the temp folder to expand this CISO (needs about ${gb} GB).` };
+  }
+
+  const dest = join(config.tempDir, `ciso-${process.pid}-${Date.now()}-${basename(filePath, extname(filePath))}.iso`);
+  const cleanup = async () => { try { await unlink(dest); } catch { /* best effort */ } };
+  const out = await open(dest, 'w');
+
+  let written = 0;
+  let lastReport = 0;
+  const buf = Buffer.allocUnsafe(COPY_CHUNK);
+  try {
+    // Blocks the dump dropped stay zero, which is what truncate leaves behind.
+    await out.truncate(isoSize);
+
+    let source = HEADER_SIZE;
+    for (let i = 0; i <= lastStored; i++) {
+      if (signal?.aborted) throw new Error('aborted');
+      if (head[MAP_OFFSET + i] === 0) continue;
+
+      const to = i * blockSize;
+      // The final block is short when the disc size is not a whole multiple, and
+      // the file itself may stop inside it.
+      const length = Math.min(blockSize, isoSize - to, fileSize - source);
+      if (length <= 0) break;
+
+      for (let done = 0; done < length; done += COPY_CHUNK) {
+        const size = Math.min(COPY_CHUNK, length - done);
+        await fh.read(buf, 0, size, source + done);
+        await out.write(buf, 0, size, to + done);
+      }
+      source += blockSize;
+      written += length;
+      if (written - lastReport >= 64 << 20) {
+        lastReport = written;
+        onProgress?.(written, covered);
+      }
+    }
+    onProgress?.(covered, covered);
+    return { path: dest, cleanup, size: isoSize };
+  } catch (e) {
+    await cleanup();
+    if (signal?.aborted) throw e;
+    return { error: `Could not expand the CISO: ${String(e.message).slice(0, 160)}` };
+  } finally {
+    await out.close();
+    await fh.close();
+  }
+}

--- a/server/src/hashing/expand.js
+++ b/server/src/hashing/expand.js
@@ -1,14 +1,17 @@
-// Compressed disc containers RAHasher cannot open on its own.
+// Disc containers RAHasher cannot open on its own.
 //
-// RAHasher only reads raw images, so a .cso/.zso or .rvz/.wia is expanded into a
-// plain .iso in temp first and removed again straight after hashing. Both paths
-// return the same shape, so callers only need this one entry point.
+// RAHasher only reads raw images, so a .cso/.zso, .rvz/.wia, .gcz or .wbfs is
+// turned back into a plain .iso in temp first and removed again straight after
+// hashing. Every path returns the same shape, so callers need this one entry
+// point only.
 import { isCsoPath, expandCso } from './cso.js';
 import { isRvzPath, expandRvz } from './rvz.js';
 import { isGczPath, expandGcz } from './gcz.js';
+import { isWbfsPath, expandWbfs } from './wbfs.js';
+import { expandGameCubeCiso } from './ciso-gc.js';
 
 export function isCompressedDisc(filePath) {
-  return isCsoPath(filePath) || isRvzPath(filePath) || isGczPath(filePath);
+  return isCsoPath(filePath) || isRvzPath(filePath) || isGczPath(filePath) || isWbfsPath(filePath);
 }
 
 /**
@@ -21,8 +24,13 @@ export function isCompressedDisc(filePath) {
  */
 export async function expandDiscImage(filePath, displayPath, options) {
   const name = displayPath ?? filePath;
-  if (isCsoPath(name)) return expandCso(filePath, options);
+  if (isCsoPath(name)) {
+    // `.ciso` names two unrelated formats. expandCso reads the PSP one and
+    // returns null for anything else, which leaves the GameCube/Wii layout.
+    return (await expandCso(filePath, options)) ?? expandGameCubeCiso(filePath, options);
+  }
   if (isRvzPath(name)) return expandRvz(filePath, options);
   if (isGczPath(name)) return expandGcz(filePath, options);
+  if (isWbfsPath(name)) return expandWbfs(filePath, options);
   return null;
 }

--- a/server/src/hashing/index.js
+++ b/server/src/hashing/index.js
@@ -6,6 +6,7 @@ import { hashFile, hashBuffer, md5 } from './file-hash.js';
 import { readEntry } from './archive.js';
 import { hashWithRAHasher, isRAHasherAvailable } from './rahasher.js';
 import { isCompressedDisc, expandDiscImage } from './expand.js';
+import { readNkitMarker, nkitMessage } from './nkit.js';
 
 // FBNeo parent-folder names that get prefixed into the arcade name hash.
 const ARCADE_KNOWN_PARENTS = new Set([
@@ -110,6 +111,11 @@ async function rahasherWithExpansion(consoleId, filePath, displayPath, { signal,
     if (expanded?.path) { target = expanded.path; cleanup = expanded.cleanup; }
   }
   try {
+    // An NKit image would hash without complaint and match nothing, so say what
+    // it is instead. Checked after expansion, which also covers a .nkit.gcz.
+    const nkit = await readNkitMarker(target);
+    if (nkit) return { status: 'error', message: nkitMessage(nkit) };
+
     phase('rahasher');
     const res = await hashWithRAHasher(consoleId, target, { signal, timeoutMs });
     if (res.md5) return { md5: res.md5, method: 'rahasher' };

--- a/server/src/hashing/nkit.js
+++ b/server/src/hashing/nkit.js
@@ -1,0 +1,53 @@
+// NKit image detection.
+//
+// NKit re-encodes a GameCube or Wii dump to make it smaller: it strips the
+// padding the disc was mastered with and, on Wii, stores partitions decrypted.
+// The result is not a disc image any more, but it keeps the original disc header
+// in its first 0x200 bytes and is usually named `.nkit.iso` — so both the file
+// extension and the magic word RAHasher checks look exactly right.
+//
+// That combination is the problem. RAHasher does not fail on an NKit image, it
+// walks it and produces a hash, which then matches nothing. A scan reports "no
+// match" for a game RetroAchievements fully supports, with nothing to suggest the
+// file is at fault. Verified with the two images this was written against:
+//
+//   Super Smash Bros. Melee   -> d098c4d278305000df2dfdc0e9c90590  (RA has
+//     326d2c2de5c8957637780da332ab9dbb and 8f0b014a1da84167f3f8f8b2145b95cd)
+//   New Super Mario Bros. Wii -> 530df2585951b6f0e420dbeee959fb30  (RA has
+//     22072114884813d3693de1bf8ab04270 and d989877def8288eb15970fa3e1d398dd)
+//
+// So the marker is read before hashing and the file is reported for what it is.
+// Restoring one needs NKit itself; the format has no published specification.
+import { open } from 'node:fs/promises';
+
+// NKit writes "NKIT" and a version right after the copied disc header.
+const MARKER_OFFSET = 0x200;
+const MARKER = 'NKIT';
+const MARKER_LENGTH = 8; // "NKIT v01"
+
+/**
+ * Returns the marker string (e.g. "NKIT v01") when the file is an NKit image,
+ * or null for anything else — including files too short to hold a marker.
+ */
+export async function readNkitMarker(filePath) {
+  let fh;
+  try {
+    fh = await open(filePath, 'r');
+    const buf = Buffer.alloc(MARKER_LENGTH);
+    const { bytesRead } = await fh.read(buf, 0, MARKER_LENGTH, MARKER_OFFSET);
+    if (bytesRead < MARKER_LENGTH) return null;
+    if (buf.toString('latin1', 0, MARKER.length) !== MARKER) return null;
+    // Keep only what is printable: the bytes after the version are binary.
+    return buf.toString('latin1').replace(/[^\x20-\x7e]+$/, '').trim();
+  } catch {
+    return null; // unreadable files are the caller's problem, not this check's
+  } finally {
+    await fh?.close();
+  }
+}
+
+export function nkitMessage(marker) {
+  return `This is an ${marker} image, not a plain disc dump. NKit strips the padding the ` +
+    'disc was mastered with, so its hash can never match RetroAchievements. Convert it back ' +
+    'to a full .iso with the NKit tool and scan it again.';
+}

--- a/server/src/hashing/wbfs.js
+++ b/server/src/hashing/wbfs.js
@@ -1,0 +1,205 @@
+// WBFS (the container USB loaders keep Wii games in) support.
+//
+// RAHasher cannot open one — it reads the WBFS header as if it were the disc and
+// reports "Not a supported Wii file" — so a .wbfs is turned back into a plain
+// .iso in the temp folder, like .rvz, .gcz and .cso.
+//
+// Unlike those, WBFS does not compress: it is a sector map. The partition is cut
+// into "wbfs sectors" (2 MiB is usual) and only the ones a disc actually uses are
+// stored, in whatever order they were written. A table per disc says where each
+// logical sector ended up.
+//
+//   hd sector 0    wbfs_head_t: magic "WBFS", the partition's sector counts, and
+//                  a disc_table with one byte per slot (non-zero = in use)
+//   hd sector 1+   one wbfs_disc_info_t per slot: the disc's first 0x100 bytes
+//                  followed by a be16 per logical sector, naming the wbfs sector
+//                  it lives in — or 0 for a sector the disc never used
+//
+// All integers are big endian. Layout and constants follow libwbfs (Wiimm's
+// wiimms-iso-tools, project/src/libwbfs).
+//
+// One consequence worth stating plainly: **the reconstruction is not byte-exact**
+// and cannot be. A real disc fills its unused areas with pseudo-random padding;
+// WBFS throws those sectors away, and nothing in the file records what was in
+// them, so they come back as zeroes. That does not affect the RetroAchievements
+// hash, which only reads partition data — the part WBFS always keeps — but it
+// does mean this expansion is verified by hash rather than by comparing bytes.
+import { open, stat, unlink, statfs } from 'node:fs/promises';
+import { join, basename, extname } from 'node:path';
+import { config } from '../config.js';
+
+const WII_SECTOR_SIZE = 0x8000;
+const WII_SECTOR_SHIFT = 15;
+// The disc sizes the format is built around: a single-layer disc, and the
+// theoretical maximum a wlba table can address.
+const WII_SECTORS_SINGLE_LAYER = 143432;
+const WII_MAX_SECTORS = 2 * WII_SECTORS_SINGLE_LAYER;
+const SINGLE_LAYER_SIZE = WII_SECTORS_SINGLE_LAYER * WII_SECTOR_SIZE; // 4,699,979,776
+// What a dual-layer Wii dump measures, which is less than the addressable maximum.
+const DUAL_LAYER_SIZE = 259740 * WII_SECTOR_SIZE; // 8,511,160,320
+
+const DISC_INFO_HEADER = 0x100;
+const COPY_CHUNK = 4 << 20;
+
+export function isWbfsPath(filePath) {
+  return extname(String(filePath)).toLowerCase() === '.wbfs';
+}
+
+async function readExact(fh, size, position) {
+  const buf = Buffer.alloc(size);
+  let got = 0;
+  while (got < size) {
+    const { bytesRead } = await fh.read(buf, got, size - got, position + got);
+    if (bytesRead === 0) throw new Error(`file ends at ${position + got}, wanted ${position + size}`);
+    got += bytesRead;
+  }
+  return buf;
+}
+
+// Parse the header and the first used disc's sector map. Returns null when the
+// file is not a WBFS, so the caller can hash it exactly as before.
+async function readWbfsIndex(fh, fileSize) {
+  const head = Buffer.alloc(0x10);
+  const { bytesRead } = await fh.read(head, 0, 0x10, 0);
+  if (bytesRead < 0x10) return null;
+  if (head.toString('latin1', 0, 4) !== 'WBFS') return null;
+
+  const hdSectorShift = head[8];
+  const wbfsSectorShift = head[9];
+  if (hdSectorShift < 9 || hdSectorShift > 16) throw new Error(`implausible hd sector shift ${hdSectorShift}`);
+  if (wbfsSectorShift < WII_SECTOR_SHIFT || wbfsSectorShift > 32) {
+    throw new Error(`implausible wbfs sector shift ${wbfsSectorShift}`);
+  }
+  const hdSectorSize = 1 << hdSectorShift;
+  const wbfsSectorSize = 2 ** wbfsSectorShift;
+
+  // How many logical sectors a disc's table covers, and how much room that table
+  // takes once padded out to whole hd sectors.
+  const sectorsPerDisc = WII_MAX_SECTORS >> (wbfsSectorShift - WII_SECTOR_SHIFT);
+  if (sectorsPerDisc < 1) throw new Error('wbfs sector size is larger than a disc');
+  const infoSize = Math.ceil((DISC_INFO_HEADER + sectorsPerDisc * 2) / hdSectorSize) * hdSectorSize;
+
+  // The disc table fills the rest of hd sector 0, one byte per slot.
+  const table = await readExact(fh, hdSectorSize, 0);
+  let slot = -1;
+  let discCount = 0;
+  for (let i = 0x0c; i < hdSectorSize; i++) {
+    if (table[i] === 0) continue;
+    discCount++;
+    if (slot < 0) slot = i - 0x0c;
+  }
+  if (slot < 0) throw new Error('the disc table is empty');
+
+  const infoOffset = hdSectorSize + slot * infoSize;
+  if (infoOffset + infoSize > fileSize) throw new Error('the disc table points past the end of the file');
+  const info = await readExact(fh, infoSize, infoOffset);
+  const wlba = info.subarray(DISC_INFO_HEADER, DISC_INFO_HEADER + sectorsPerDisc * 2);
+
+  return { wbfsSectorSize, sectorsPerDisc, wlba, discCount };
+}
+
+// Is there room in temp for the expanded image (plus 15% headroom)?
+async function tempHasRoom(bytes) {
+  try {
+    const fs = await statfs(config.tempDir);
+    return fs.bavail * fs.bsize >= bytes * 1.15;
+  } catch { return true; }
+}
+
+/**
+ * Expand a .wbfs into a plain .iso in the temp folder.
+ *
+ * Returns { path, cleanup, size } on success, { error } when it cannot be read,
+ * or null when the file is not a WBFS at all. `onProgress(done, total)` reports
+ * written bytes.
+ */
+export async function expandWbfs(filePath, { signal, onProgress } = {}) {
+  const fh = await open(filePath, 'r');
+  const fileSize = (await stat(filePath)).size;
+  let index;
+  try {
+    index = await readWbfsIndex(fh, fileSize);
+  } catch (e) {
+    await fh.close();
+    return { error: `Could not read the WBFS header: ${String(e.message).slice(0, 160)}` };
+  }
+  if (!index) {
+    await fh.close();
+    return null;
+  }
+
+  const { wbfsSectorSize, sectorsPerDisc, wlba, discCount } = index;
+  if (discCount > 1) {
+    await fh.close();
+    return { error: `This WBFS holds ${discCount} discs; RAChecker can only hash a single-disc one.` };
+  }
+
+  // Everything past the last stored sector is padding on the real disc, so the
+  // image is grown to whatever standard size covers what is here.
+  let lastUsed = -1;
+  for (let i = 0; i < sectorsPerDisc; i++) if (wlba.readUInt16BE(i * 2) !== 0) lastUsed = i;
+  if (lastUsed < 0) {
+    await fh.close();
+    return { error: 'This WBFS stores no sectors for its disc.' };
+  }
+  const covered = (lastUsed + 1) * wbfsSectorSize;
+  // The disc only has to be big enough to *reach* the last stored sector: that
+  // sector usually straddles the end of the image, so rounding up to whole wbfs
+  // sectors first would push a single-layer disc into the dual-layer size.
+  const minimum = lastUsed * wbfsSectorSize + 1;
+  const isoSize = minimum <= SINGLE_LAYER_SIZE ? SINGLE_LAYER_SIZE
+    : minimum <= DUAL_LAYER_SIZE ? DUAL_LAYER_SIZE
+      : Math.ceil(covered / WII_SECTOR_SIZE) * WII_SECTOR_SIZE;
+
+  if (!(await tempHasRoom(isoSize))) {
+    await fh.close();
+    const gb = (isoSize / 1024 ** 3).toFixed(1);
+    return { error: `Not enough free space in the temp folder to expand this WBFS (needs about ${gb} GB).` };
+  }
+
+  const dest = join(config.tempDir, `wbfs-${process.pid}-${Date.now()}-${basename(filePath, extname(filePath))}.iso`);
+  const cleanup = async () => { try { await unlink(dest); } catch { /* best effort */ } };
+  const out = await open(dest, 'w');
+
+  let written = 0;
+  let lastReport = 0;
+  const buf = Buffer.allocUnsafe(COPY_CHUNK);
+  try {
+    // Sectors the disc never used stay zero, which is what truncate leaves behind.
+    await out.truncate(isoSize);
+
+    for (let i = 0; i <= lastUsed; i++) {
+      if (signal?.aborted) throw new Error('aborted');
+      const physical = wlba.readUInt16BE(i * 2);
+      if (physical === 0) continue;
+
+      const from = physical * wbfsSectorSize;
+      const to = i * wbfsSectorSize;
+      if (from >= fileSize) throw new Error(`logical sector ${i} points past the end of the file`);
+      // Two ways a sector can be short of a full 2 MiB: the disc size is not a
+      // whole multiple of the wbfs sector size, and the physical sector written
+      // last is only as long as the data in it, so the file simply stops there.
+      const length = Math.min(wbfsSectorSize, isoSize - to, fileSize - from);
+
+      for (let done = 0; done < length; done += COPY_CHUNK) {
+        const size = Math.min(COPY_CHUNK, length - done);
+        await fh.read(buf, 0, size, from + done);
+        await out.write(buf, 0, size, to + done);
+      }
+      written += length;
+      if (written - lastReport >= 64 << 20) {
+        lastReport = written;
+        onProgress?.(written, covered);
+      }
+    }
+    onProgress?.(covered, covered);
+    return { path: dest, cleanup, size: isoSize };
+  } catch (e) {
+    await cleanup();
+    if (signal?.aborted) throw e;
+    return { error: `Could not expand the WBFS: ${String(e.message).slice(0, 160)}` };
+  } finally {
+    await out.close();
+    await fh.close();
+  }
+}

--- a/server/test/ciso-gc.test.js
+++ b/server/test/ciso-gc.test.js
@@ -1,0 +1,126 @@
+// Tests for GameCube/Wii CISO expansion (server/src/hashing/ciso-gc.js).
+//
+// This format shares its magic word with the PSP CSO that cso.js reads and has
+// nothing else in common with it, so half of what matters here is that each
+// reader leaves the other's files alone.
+//
+// Like WBFS, a CISO drops blocks rather than compressing them, so a dump can end
+// before the disc does. The image is grown back to the disc's real size, which is
+// created with truncate and left sparse — the fixtures below therefore cost
+// almost nothing on disk despite expanding to 1.4 GB.
+//
+// ciso-gc.js writes into config.tempDir, so RA_DATA_DIR points at a throwaway
+// directory BEFORE the import.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, openSync, readSync, closeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tempDataDir = mkdtempSync(join(tmpdir(), 'ra-checker-ciso-'));
+process.env.RA_DATA_DIR = tempDataDir;
+
+let ciso;
+before(async () => { ciso = await import('../src/hashing/ciso-gc.js'); });
+after(() => { try { rmSync(tempDataDir, { recursive: true, force: true }); } catch { /* windows file locks */ } });
+
+const HEADER = 0x8000;
+const BLOCK = 0x8000;
+const GAMECUBE_SIZE = 1459978240;
+
+// `present` says which blocks were kept. Each kept block is filled with a byte
+// derived from its index, so copying the wrong one cannot pass.
+function packCiso({ present, blockSize = BLOCK, magic = 'CISO', header } = {}) {
+  const head = Buffer.alloc(HEADER);
+  head.write(magic, 0, 'latin1');
+  head.writeUInt32LE(blockSize, 4);
+  const parts = [head];
+  present.forEach((kept, i) => {
+    if (!kept) return;
+    head[8 + i] = 1;
+    const block = Buffer.alloc(blockSize, 0x40 + i);
+    if (i === 0 && header) header(block);
+    parts.push(block);
+  });
+  return Buffer.concat(parts);
+}
+
+let fixtureNo = 0;
+async function expand(file) {
+  const path = join(tempDataDir, `fixture-${fixtureNo++}.ciso`);
+  writeFileSync(path, file);
+  return ciso.expandGameCubeCiso(path);
+}
+
+function byteAt(path, offset) {
+  const buf = Buffer.alloc(1);
+  const fd = openSync(path, 'r');
+  try { readSync(fd, buf, 0, 1, offset); } finally { closeSync(fd); }
+  return buf[0];
+}
+
+test('CISO: stored blocks come back at their own offsets', async () => {
+  const result = await expand(packCiso({ present: [1, 1, 1] }));
+  assert.equal(result?.error, undefined, `expandGameCubeCiso failed: ${result?.error}`);
+  try {
+    // No disc header, so nothing tells it to grow: the image is what was stored.
+    assert.equal(result.size, 3 * BLOCK);
+    const got = readFileSync(result.path);
+    for (let i = 0; i < 3; i++) {
+      assert.ok(got.subarray(i * BLOCK, (i + 1) * BLOCK).every((b) => b === 0x40 + i), `block ${i}`);
+    }
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('CISO: a dropped block comes back as zeroes', async () => {
+  const result = await expand(packCiso({ present: [1, 0, 1] }));
+  assert.equal(result?.error, undefined, `expandGameCubeCiso failed: ${result?.error}`);
+  try {
+    const got = readFileSync(result.path);
+    assert.equal(got[0], 0x40);
+    assert.ok(got.subarray(BLOCK, 2 * BLOCK).every((b) => b === 0), 'the dropped block is not zero');
+    assert.equal(got[2 * BLOCK], 0x42);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('CISO: a GameCube dump is grown back to a whole disc', async () => {
+  // A scrubbed dump stops early; a hash rule reading near the end has to find
+  // zeroes there, not the end of the file.
+  const result = await expand(packCiso({
+    present: [1, 1],
+    header: (block) => block.writeUInt32BE(0xc2339f3d, 0x1c),
+  }));
+  assert.equal(result?.error, undefined, `expandGameCubeCiso failed: ${result?.error}`);
+  try {
+    assert.equal(result.size, GAMECUBE_SIZE);
+    assert.equal(byteAt(result.path, BLOCK), 0x41);
+    assert.equal(byteAt(result.path, GAMECUBE_SIZE - 1), 0x00);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('a PSP CSO is left alone rather than read as this format', async () => {
+  // Same magic word, 2 KiB blocks. cso.js owns those; this reader must decline
+  // so the file keeps being handled the way it was.
+  assert.equal(await expand(packCiso({ present: [1], blockSize: 2048 })), null);
+});
+
+test('expandGameCubeCiso ignores files that are not CISO', async () => {
+  assert.equal(await expand(packCiso({ present: [1], magic: 'XISO' })), null);
+});
+
+test('expandGameCubeCiso rejects a dump missing its first block', async () => {
+  const result = await expand(packCiso({ present: [0, 1] }));
+  assert.match(result.error, /first block/);
+});
+
+test('expandGameCubeCiso rejects a map claiming more than the file holds', async () => {
+  const file = packCiso({ present: [1, 1, 1] });
+  const result = await expand(file.subarray(0, HEADER + BLOCK));
+  assert.match(result.error, /more blocks than the file holds/);
+});

--- a/server/test/nkit.test.js
+++ b/server/test/nkit.test.js
@@ -1,0 +1,79 @@
+// Tests for NKit detection (server/src/hashing/nkit.js).
+//
+// An NKit image keeps the original disc header in its first 0x200 bytes, so it
+// passes every check RAHasher makes and hashes to something that matches
+// nothing. The marker after that header is the only way to tell, which makes the
+// offset the thing worth pinning down: read it a few bytes early or late and the
+// check silently stops working.
+//
+// Verified against the two real images this was written for — Super Smash Bros.
+// Melee and New Super Mario Bros. Wii, both `NKIT v01` — which cannot be checked
+// in at 1.4 GB and 350 MB, hence the fixtures below.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const dir = mkdtempSync(join(tmpdir(), 'ra-checker-nkit-'));
+
+let nkit;
+before(async () => { nkit = await import('../src/hashing/nkit.js'); });
+after(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* windows file locks */ } });
+
+// A GameCube-looking header, then whatever the caller wants at 0x200 — the same
+// shape the real files have.
+function makeImage(marker, { size = 0x1000, offset = 0x200 } = {}) {
+  const buf = Buffer.alloc(size, 0x5a);
+  buf.write('GALE01', 0, 'latin1');
+  buf.writeUInt32BE(0xc2339f3d, 0x1c);
+  if (marker) buf.write(marker, offset, 'latin1');
+  return buf;
+}
+
+function write(name, buf) {
+  const path = join(dir, name);
+  writeFileSync(path, buf);
+  return path;
+}
+
+test('an NKit image is recognised and reports its version', async () => {
+  const path = write('nkit.iso', makeImage('NKIT v01'));
+  assert.equal(await nkit.readNkitMarker(path), 'NKIT v01');
+});
+
+test('the binary data after the version is not included', async () => {
+  // The real files carry a hash straight after the version, with no separator.
+  const buf = makeImage('NKIT v01');
+  Buffer.from([0x53, 0x65, 0xc8, 0x4b]).copy(buf, 0x208);
+  assert.equal(await nkit.readNkitMarker(write('nkit-tail.iso', buf)), 'NKIT v01');
+});
+
+test('a later NKit version is still recognised', async () => {
+  assert.equal(await nkit.readNkitMarker(write('nkit2.iso', makeImage('NKIT v02'))), 'NKIT v02');
+});
+
+test('a plain disc image is not mistaken for one', async () => {
+  assert.equal(await nkit.readNkitMarker(write('plain.iso', makeImage(null))), null);
+});
+
+test('the marker only counts at 0x200', async () => {
+  const early = write('early.iso', makeImage('NKIT v01', { offset: 0x1f8 }));
+  const late = write('late.iso', makeImage('NKIT v01', { offset: 0x208 }));
+  assert.equal(await nkit.readNkitMarker(early), null);
+  assert.equal(await nkit.readNkitMarker(late), null);
+});
+
+test('a file too short to hold a marker is not one', async () => {
+  assert.equal(await nkit.readNkitMarker(write('short.iso', makeImage(null, { size: 0x204 }))), null);
+});
+
+test('a file that cannot be read is not one', async () => {
+  assert.equal(await nkit.readNkitMarker(join(dir, 'does-not-exist.iso')), null);
+});
+
+test('the message names the version and says what to do', () => {
+  const message = nkit.nkitMessage('NKIT v01');
+  assert.match(message, /NKIT v01/);
+  assert.match(message, /NKit tool/);
+});

--- a/server/test/wbfs.test.js
+++ b/server/test/wbfs.test.js
@@ -1,0 +1,166 @@
+// Tests for WBFS expansion (server/src/hashing/wbfs.js).
+//
+// WBFS is a sector map, not a compressor: what it does not store is padding the
+// real disc had and nobody kept, so a reconstruction can only be checked sector
+// by sector, not by comparing whole files. These tests therefore build small
+// WBFS files with a known map and read specific offsets back out.
+//
+// The expanded image is a single-layer Wii disc — 4.7 GB — however few sectors a
+// fixture stores, because the format fixes the disc size, not the file. It is
+// created with truncate and only the mapped sectors are written, so it stays a
+// sparse file and costs almost nothing on disk; the reads below seek rather than
+// scan.
+//
+// The real check is elsewhere: a WBFS built from a genuine Super Mario Galaxy 2
+// dump expands byte-identically and hashes to c40d458e2064edb1298cf4f11e4648a5,
+// which is one of the two hashes RetroAchievements publishes for the game.
+//
+// wbfs.js writes into config.tempDir, so RA_DATA_DIR points at a throwaway
+// directory BEFORE the import.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, openSync, readSync, closeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tempDataDir = mkdtempSync(join(tmpdir(), 'ra-checker-wbfs-'));
+process.env.RA_DATA_DIR = tempDataDir;
+
+let wbfs;
+before(async () => { wbfs = await import('../src/hashing/wbfs.js'); });
+after(() => { try { rmSync(tempDataDir, { recursive: true, force: true }); } catch { /* windows file locks */ } });
+
+const HD_SHIFT = 9;
+const WB_SHIFT = 21;
+const HD = 1 << HD_SHIFT;
+const WB = 1 << WB_SHIFT;
+const SECTORS_PER_DISC = (2 * 143432) >> (WB_SHIFT - 15); // 4482
+const INFO_SIZE = Math.ceil((0x100 + SECTORS_PER_DISC * 2) / HD) * HD;
+const SINGLE_LAYER = 143432 * 0x8000;
+
+// `map` gives the wbfs sector each logical sector lives in, 0 meaning "never
+// used". Each stored sector is filled with a byte derived from its index so the
+// reader cannot pass by copying the wrong one.
+function packWbfs({ map, slots = [0], hdShift = HD_SHIFT, wbShift = WB_SHIFT, magic = 'WBFS', truncateLast = false } = {}) {
+  const highest = Math.max(0, ...map);
+  const size = (highest + 1) * WB;
+  const file = Buffer.alloc(size);
+
+  file.write(magic, 0, 'latin1');
+  file.writeUInt32BE(size / HD, 4);
+  file[8] = hdShift;
+  file[9] = wbShift;
+  file[10] = 1;
+  for (const slot of slots) file[0x0c + slot] = 1;
+
+  // Slot 0's disc info: a Wii-looking header, then the map.
+  const info = HD;
+  file.writeUInt32BE(0x5d1c9ea3, info + 0x18);
+  file.write('SMNE01', info, 'latin1');
+  map.forEach((physical, logical) => file.writeUInt16BE(physical, info + 0x100 + logical * 2));
+
+  map.forEach((physical, logical) => {
+    if (physical !== 0) file.fill(0x40 + logical, physical * WB, (physical + 1) * WB);
+  });
+  // Writers stop the file where the data stops, so the physical sector written
+  // last is usually shorter than a full one.
+  return truncateLast ? file.subarray(0, highest * WB + 0x40000) : file;
+}
+
+let fixtureNo = 0;
+async function expand(file) {
+  const path = join(tempDataDir, `fixture-${fixtureNo++}.wbfs`);
+  writeFileSync(path, file);
+  return { result: await wbfs.expandWbfs(path), path };
+}
+
+// Read one byte at the start of a logical sector without pulling in the file.
+function byteAt(path, offset) {
+  const buf = Buffer.alloc(1);
+  const fd = openSync(path, 'r');
+  try { readSync(fd, buf, 0, 1, offset); } finally { closeSync(fd); }
+  return buf[0];
+}
+
+test('WBFS: mapped sectors land at their logical offsets', async () => {
+  // Deliberately out of order: the map, not the file order, decides.
+  const { result } = await expand(packWbfs({ map: [2, 1, 3] }));
+  assert.equal(result?.error, undefined, `expandWbfs failed: ${result?.error}`);
+  try {
+    assert.equal(byteAt(result.path, 0 * WB), 0x40);
+    assert.equal(byteAt(result.path, 1 * WB), 0x41);
+    assert.equal(byteAt(result.path, 2 * WB), 0x42);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('WBFS: an unused sector reads back as zeroes', async () => {
+  const { result } = await expand(packWbfs({ map: [1, 0, 2] }));
+  assert.equal(result?.error, undefined, `expandWbfs failed: ${result?.error}`);
+  try {
+    assert.equal(byteAt(result.path, 0 * WB), 0x40);
+    assert.equal(byteAt(result.path, 1 * WB), 0x00);
+    assert.equal(byteAt(result.path, 2 * WB), 0x42);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('WBFS: the image is a whole single-layer disc, not just what is stored', async () => {
+  const { result } = await expand(packWbfs({ map: [1, 2] }));
+  try {
+    assert.equal(result.size, SINGLE_LAYER);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('WBFS: the last sector straddling the end does not force a dual-layer image', async () => {
+  // Logical sector 2241 starts inside a single-layer disc but ends past it —
+  // rounding up to whole wbfs sectors first would double the image size.
+  const map = new Array(2242).fill(0);
+  map[0] = 1;
+  map[2241] = 2;
+  const { result } = await expand(packWbfs({ map }));
+  try {
+    assert.equal(result.size, SINGLE_LAYER);
+    assert.equal(byteAt(result.path, 2241 * WB), (0x40 + 2241) & 0xff);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('WBFS: a file that stops inside its last sector still expands', async () => {
+  // Found the hard way: a real WBFS ends where its data ends, so insisting on a
+  // full final sector rejected a perfectly good file.
+  const { result } = await expand(packWbfs({ map: [1, 2], truncateLast: true }));
+  assert.equal(result?.error, undefined, `expandWbfs failed: ${result?.error}`);
+  try {
+    assert.equal(byteAt(result.path, 0 * WB), 0x40);
+    assert.equal(byteAt(result.path, 1 * WB), 0x41);
+  } finally {
+    await result.cleanup();
+  }
+});
+
+test('expandWbfs ignores files that are not WBFS', async () => {
+  const { result } = await expand(packWbfs({ map: [1], magic: 'XBFS' }));
+  assert.equal(result, null);
+});
+
+test('expandWbfs refuses a WBFS holding several discs', async () => {
+  const { result } = await expand(packWbfs({ map: [1], slots: [0, 1] }));
+  assert.match(result.error, /2 discs/);
+});
+
+test('expandWbfs rejects an implausible sector size', async () => {
+  const { result } = await expand(packWbfs({ map: [1], wbShift: 8 }));
+  assert.match(result.error, /wbfs sector shift/);
+});
+
+test('isWbfsPath covers the extension and nothing else', () => {
+  assert.equal(wbfs.isWbfsPath('C:/roms/Game.WBFS'), true);
+  assert.equal(wbfs.isWbfsPath('/roms/Game.iso'), false);
+  assert.equal(wbfs.isWbfsPath('/roms/Game.rvz'), false);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-checker-web",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version + changelog. The footer version
 // chip opens a modal rendering CHANGELOG; package.json is kept in sync manually.
-export const APP_VERSION = '0.16.0';
+export const APP_VERSION = '0.17.0';
 
 // GitHub repository — linked from the header (GitHub icon in the "More" menu).
 export const REPO_URL = 'https://github.com/x3kim/RAChecker';
@@ -15,6 +15,16 @@ export interface Release { version: string; date: string; title?: { de: string; 
 
 // Newest first. Dates are ISO (YYYY-MM-DD).
 export const CHANGELOG: Release[] = [
+  {
+    version: '0.17.0',
+    date: '2026-08-19',
+    title: { de: 'WBFS, CISO und NKit-Erkennung', en: 'WBFS, CISO and NKit detection' },
+    changes: [
+      { type: 'fix', de: 'NKit-Images werden endlich erkannt. NKit verkleinert einen Dump, indem es das Padding entfernt, mit dem die Disc gemastert wurde — die Datei behält aber die Endung .iso und einen echten Disc-Header. RAHasher hasht sie deshalb klaglos, nur passt das Ergebnis zu nichts: RAChecker meldete „kein Treffer“ für Spiele, die RetroAchievements voll unterstützt, ohne jeden Hinweis auf die Ursache. Jetzt steht da, was die Datei ist und was zu tun ist.', en: 'NKit images are recognised at last. NKit shrinks a dump by stripping the padding the disc was mastered with, but the file keeps the .iso extension and a genuine disc header. RAHasher therefore hashes it without complaint, and the result matches nothing: RAChecker reported „no match“ for games RetroAchievements fully supports, with no hint as to why. It now says what the file is and what to do about it.' },
+      { type: 'feature', de: 'WBFS-Dateien werden gehasht — das Format, in dem USB-Loader Wii-Spiele ablegen. RAHasher las bei einer .wbfs den Container-Kopf, als wäre er die Disc, und wies die Datei ab. Sie wird jetzt zum Hashen kurz in eine echte .iso zurückverwandelt.', en: 'WBFS files are hashed — the format USB loaders keep Wii games in. RAHasher read a .wbfs container header as if it were the disc and rejected the file. It is now turned back into a real .iso for the moment it takes to hash.' },
+      { type: 'feature', de: 'Die GameCube- und Wii-Variante von .ciso wird ebenfalls gehasht. Die Endung steht für zwei völlig verschiedene Formate — PSP-Dumps benutzen sie anders als GameCube-Werkzeuge — und nur das PSP-Format wurde bisher gelesen.', en: 'The GameCube and Wii flavour of .ciso is hashed as well. The extension names two completely different formats — PSP dumps use it one way, GameCube tools another — and only the PSP one was read before.' },
+    ],
+  },
   {
     version: '0.16.0',
     date: '2026-08-18',


### PR DESCRIPTION
Three more containers RAHasher opens as though the wrapper were the disc. Two it
rejects outright, which at least says *something*. The third it hashes happily,
which says the wrong thing — and that one is in your own collection.

## NKit: a confident wrong answer

NKit shrinks a dump by stripping the padding the disc was mastered with. It
keeps the original disc header in the first 0x200 bytes and is named
`.nkit.iso`, so the extension, the magic word and everything else RAHasher
checks look right. It hashes without complaint, and the hash matches nothing:

| File | RAHasher says | RetroAchievements publishes |
|---|---|---|
| Super Smash Bros. Melee | `d098c4d2…` | `326d2c2d…`, `8f0b014a…` |
| New Super Mario Bros. Wii | `530df258…` | `22072114…`, `d989877d…` |

Both games are fully supported. A scan reported "no match" with nothing to
suggest the file was at fault — no error, no warning, and no extension check
that could catch it.

`server/src/hashing/nkit.js` reads the `NKIT` marker at 0x200 and reports the
file for what it is. Checked *after* expansion, so a `.nkit.gcz` is caught too.
Restoring one needs NKit itself — the format has no published specification.

## WBFS

What USB loaders keep Wii games in: a sector map rather than a compressor. Only
the sectors a disc used are stored, in whatever order they were written, with a
table per disc saying where each logical sector went. Layout and constants follow
libwbfs.

Worth stating plainly in the code and here: **the reconstruction is not
byte-exact and cannot be.** A real disc fills its unused areas with pseudo-random
padding; WBFS discards those sectors and nothing records what was in them, so
they come back as zeroes. That never reaches the hash, which only reads partition
data — the part WBFS always keeps.

## GameCube/Wii CISO

Shares its magic word with the PSP CSO `cso.js` already read, and nothing else: a
presence map with one byte per block, then the kept blocks back to back.

`cso.js` declines anything that is not a PSP CSO, so `expandDiscImage` falls
through to the new reader — and the new reader declines the block sizes the PSP
format uses, so neither can swallow the other's files. There is a test for each
direction.

Both WBFS and CISO drop blocks rather than compressing them, so a dump can stop
before the disc does. The image is grown back to the disc's real size, taken from
the header, rather than truncated where the data happens to end — otherwise a
hash rule reading near the end finds EOF instead of the zeroes that belong there.

## Verification — against real dumps this time

1. **Two genuine Super Mario Galaxy 2 RVZ files** (Zstandard, 128 KiB chunks —
   exactly the case that started all this) expand to 4.70 GB in ~90 s each and
   hash to **both** of the only two hashes RA publishes for the game:
   `201a78d50fe2cf7ea7ed213e5c472ef3` (Europe) and
   `c40d458e2064edb1298cf4f11e4648a5` (USA).

   That also retroactively confirms the Wii partition rebuild shipped in 0.15.0 —
   hash tree, exceptions, AES, junk generator — which until now had only ever been
   round-tripped against this repo's own encoder. Two implementations sharing one
   misunderstanding would have passed that; real Nintendo mastering does not.

2. **A WBFS built from that proven ISO** expands byte-identically and hashes to
   `c40d458e…` through `hashTarget`, end to end. It also found a bug the synthetic
   fixtures could not: a real WBFS ends where its data ends, so its last physical
   sector is short, and insisting on a full one rejected a perfectly good file.
   Now pinned down by a test.

3. **A GameCube CISO** hashes identically to the plain `.iso` through
   `hashTarget`.

153/153 tests green, `tsc` clean.

`.nrg` is still unchecked: it is in no console's extension list, so nothing
reaches it, and confirming that properly needs a PlayStation or Saturn image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support WBFS and GameCube/Wii CISO hashing while identifying NKit images before they produce misleading hashes.

New Features:
- Add support for hashing WBFS Wii images by expanding them to temporary ISO files.
- Add support for hashing GameCube/Wii CISO images while preserving existing PSP CISO handling.

Bug Fixes:
- Detect NKit images before hashing and report that they must be restored to a full ISO instead of producing misleading no-match results.

Enhancements:
- Handle sparse container images by restoring their expected disc size and zero-filled regions during expansion.
- Update supported Wii and GameCube container documentation and release metadata for version 0.17.0.

Documentation:
- Document WBFS and GameCube/Wii CISO support and explain NKit detection and conversion requirements.

Tests:
- Add coverage for WBFS expansion, truncated final sectors, multi-disc rejection, and sector mapping.
- Add coverage for GameCube/Wii CISO expansion, sparse blocks, disc sizing, and PSP CISO compatibility.
- Add coverage for NKit marker detection and user-facing diagnostics.